### PR TITLE
fix: add primary keys to candle tables

### DIFF
--- a/migrations/1700000000000_init.js
+++ b/migrations/1700000000000_init.js
@@ -16,7 +16,7 @@ export async function up(pgm) {
       volume: 'numeric'
     },
     {
-      primaryKey: ['symbol', 'open_time']
+      constraints: { primaryKey: ['symbol', 'open_time'] }
     }
   );
 
@@ -28,7 +28,7 @@ export async function up(pgm) {
       data: { type: 'jsonb', notNull: true }
     },
     {
-      primaryKey: ['symbol', 'open_time']
+      constraints: { primaryKey: ['symbol', 'open_time'] }
     }
   );
 
@@ -40,7 +40,7 @@ export async function up(pgm) {
       data: { type: 'jsonb', notNull: true }
     },
     {
-      primaryKey: ['symbol', 'open_time']
+      constraints: { primaryKey: ['symbol', 'open_time'] }
     }
   );
 
@@ -70,7 +70,6 @@ export async function up(pgm) {
     run_at: { type: 'bigint' }
   });
 
-  pgm.createIndex('candles_1m', ['symbol', 'open_time']);
   pgm.createIndex('signals', ['symbol', 'open_time']);
 }
 


### PR DESCRIPTION
## Summary
- fix migration primary key definitions for candle, indicator and pattern tables
- remove redundant candles index

## Testing
- `npm test` *(fails: hammer pattern expectation; fetch integration network)*

------
https://chatgpt.com/codex/tasks/task_e_68c0b5ff7ae8832590353864cfce5e29