### PR TITLE
feat: add indicator, pattern, and strategy helpers

### DIFF
--- a/src/core/indicators/hhll.js
+++ b/src/core/indicators/hhll.js
@@ -1,6 +1,13 @@
 export function hhll(highs, lows) {
-  if (highs.length < 2 || lows.length < 2) return { hh: false, ll: false };
-  const hh = highs[highs.length - 1] > highs[highs.length - 2];
-  const ll = lows[lows.length - 1] < lows[lows.length - 2];
-  return { hh, ll };
+  if (highs.length < 2 || lows.length < 2) {
+    return { hh: false, hl: false, lh: false, ll: false };
+  }
+  const [prevHigh, currHigh] = highs.slice(-2);
+  const [prevLow, currLow] = lows.slice(-2);
+  return {
+    hh: currHigh > prevHigh,
+    hl: currLow > prevLow,
+    lh: currHigh < prevHigh,
+    ll: currLow < prevLow
+  };
 }

--- a/src/core/indicators/rsi14.js
+++ b/src/core/indicators/rsi14.js
@@ -1,19 +1,27 @@
-export function rsi14(closes) {
-  const period = 14;
-  if (closes.length < period + 1) return null;
-  let gains = 0;
-  let losses = 0;
+export function rsi14(values, period = 14) {
+  if (values.length < period + 1) {
+    throw new Error('not enough data');
+  }
+
+  let gainSum = 0;
+  let lossSum = 0;
   for (let i = 1; i <= period; i++) {
-    const diff = closes[i] - closes[i - 1];
-    if (diff >= 0) gains += diff; else losses -= diff;
+    const diff = values[i] - values[i - 1];
+    if (diff > 0) gainSum += diff;
+    else lossSum -= diff;
   }
-  let avgGain = gains / period;
-  let avgLoss = losses / period;
-  for (let i = period + 1; i < closes.length; i++) {
-    const diff = closes[i] - closes[i - 1];
-    avgGain = (avgGain * (period - 1) + Math.max(diff, 0)) / period;
-    avgLoss = (avgLoss * (period - 1) + Math.max(-diff, 0)) / period;
+  let avgGain = gainSum / period;
+  let avgLoss = lossSum / period;
+
+  for (let i = period + 1; i < values.length; i++) {
+    const diff = values[i] - values[i - 1];
+    const gain = diff > 0 ? diff : 0;
+    const loss = diff < 0 ? -diff : 0;
+    avgGain = (avgGain * (period - 1) + gain) / period;
+    avgLoss = (avgLoss * (period - 1) + loss) / period;
   }
-  const rs = avgLoss === 0 ? 100 : avgGain / avgLoss;
+
+  if (avgLoss === 0) return 100;
+  const rs = avgGain / avgLoss;
   return 100 - 100 / (1 + rs);
 }

--- a/src/core/indicators/trend.js
+++ b/src/core/indicators/trend.js
@@ -1,8 +1,8 @@
 export function trend(closes) {
   if (closes.length < 2) return 'flat';
+  const first = closes[0];
   const last = closes[closes.length - 1];
-  const prev = closes[closes.length - 2];
-  if (last > prev) return 'up';
-  if (last < prev) return 'down';
+  if (last > first) return 'up';
+  if (last < first) return 'down';
   return 'flat';
 }

--- a/src/core/patterns/bullishEngulfing.js
+++ b/src/core/patterns/bullishEngulfing.js
@@ -1,8 +1,9 @@
-export function bullishEngulfing(c1, c2) {
-  return (
-    c1.close < c1.open &&
-    c2.close > c2.open &&
-    c2.open <= c1.close &&
-    c2.close >= c1.open
-  );
+export function bullishEngulfing(prev, curr) {
+  const prevBearish = prev.close < prev.open;
+  const currBullish = curr.close > curr.open;
+  const prevLow = Math.min(prev.open, prev.close);
+  const prevHigh = Math.max(prev.open, prev.close);
+  const currLow = Math.min(curr.open, curr.close);
+  const currHigh = Math.max(curr.open, curr.close);
+  return prevBearish && currBullish && currLow <= prevLow && currHigh >= prevHigh;
 }

--- a/src/core/patterns/hammer.js
+++ b/src/core/patterns/hammer.js
@@ -1,6 +1,6 @@
 export function hammer(c) {
   const body = Math.abs(c.close - c.open);
-  const lower = c.open < c.close ? c.open - c.low : c.close - c.low;
-  const upper = c.high - Math.max(c.open, c.close);
-  return lower >= body * 2 && upper <= body * 0.3;
+  const lowerWick = Math.min(c.open, c.close) - c.low;
+  const upperWick = c.high - Math.max(c.open, c.close);
+  return lowerWick >= 2 * body && upperWick <= body;
 }

--- a/src/core/signals/engine.js
+++ b/src/core/signals/engine.js
@@ -1,6 +1,18 @@
 export function runStrategy(strategy, indicators) {
-  for (const rule of strategy.rules) {
-    if (rule.when(indicators)) return rule.signal;
+  if (!strategy) return null;
+  if (Array.isArray(strategy.rules)) {
+    for (const rule of strategy.rules) {
+      if (rule.when(indicators)) return rule.signal;
+    }
+    return null;
+  }
+  if (typeof strategy.entry === 'function') {
+    const entry = strategy.entry(indicators);
+    if (entry) return entry;
+  }
+  if (typeof strategy.exit === 'function') {
+    const exit = strategy.exit(indicators);
+    if (exit) return exit;
   }
   return null;
 }

--- a/src/core/signals/strategies/SidewaysReversal.js
+++ b/src/core/signals/strategies/SidewaysReversal.js
@@ -1,9 +1,15 @@
-const strategy = {
+export default {
   name: 'SidewaysReversal',
-  rules: [
-    { when: i => i.trend === 'flat' && i.hhll.hh, signal: 'buy' },
-    { when: i => i.trend === 'flat' && i.hhll.ll, signal: 'sell' }
-  ]
+  entry(ind) {
+    if (ind.hhll?.hh && !ind.hhll?.ll) {
+      return 'buy';
+    }
+    return null;
+  },
+  exit(ind) {
+    if (ind.hhll?.ll) {
+      return 'sell';
+    }
+    return null;
+  }
 };
-
-export default strategy;


### PR DESCRIPTION
## Summary
- implement RSI14, trend, and HHLL indicators
- add bullish engulfing and hammer pattern detectors
- support flexible signal engine and SidewaysReversal strategy

## Testing
- `npm test` *(fails: FetchError connect ENETUNREACH)*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c0baf5c51c8325a0f0ed90c0d66746