### PR TITLE
Add database initialization SQL script and db init command

### DIFF
--- a/migrations/db.init.sql
+++ b/migrations/db.init.sql
@@ -1,0 +1,93 @@
+-- Database initialization script
+-- Creates core tables and indexes for crypto-signals-cli
+
+create table if not exists symbols (
+  symbol text primary key,
+  base text,
+  quote text,
+  is_active boolean default true
+);
+
+create table if not exists candles_1m (
+  id bigserial primary key,
+  symbol text,
+  ts timestamptz,
+  open numeric,
+  high numeric,
+  low numeric,
+  close numeric,
+  volume numeric,
+  unique(symbol, ts)
+);
+
+create table if not exists indicators_1m (
+  id bigserial primary key,
+  symbol text,
+  ts timestamptz,
+  rsi14 numeric,
+  atr14 numeric,
+  aroon_up25 numeric,
+  aroon_down25 numeric,
+  bb_mid20 numeric,
+  bb_upper20_2 numeric,
+  bb_lower20_2 numeric,
+  trend text,
+  hhll text,
+  unique(symbol, ts)
+);
+
+create table if not exists patterns_1m (
+  id bigserial primary key,
+  symbol text,
+  ts timestamptz,
+  bullish_engulfing boolean,
+  bearish_engulfing boolean,
+  hammer boolean,
+  shooting_star boolean,
+  unique(symbol, ts)
+);
+
+create table if not exists signals (
+  id bigserial primary key,
+  symbol text,
+  ts timestamptz,
+  side text,
+  reason jsonb,
+  strategy text,
+  confidence numeric default 1.0
+);
+
+create table if not exists trades_paper (
+  id bigserial primary key,
+  symbol text,
+  ts_open timestamptz,
+  ts_close timestamptz,
+  side text,
+  qty numeric,
+  entry numeric,
+  exit numeric,
+  pnl numeric,
+  status text
+);
+
+create table if not exists equity_paper (
+  id bigserial primary key,
+  ts timestamptz,
+  equity numeric,
+  source text
+);
+
+create table if not exists jobs (
+  id bigserial primary key,
+  type text,
+  params jsonb,
+  status text,
+  started_at timestamptz,
+  finished_at timestamptz,
+  error text
+);
+
+create index if not exists idx_candles_1m_symbol_ts on candles_1m(symbol, ts);
+create index if not exists idx_indicators_1m_symbol_ts on indicators_1m(symbol, ts);
+create index if not exists idx_patterns_1m_symbol_ts on patterns_1m(symbol, ts);
+create index if not exists idx_signals_symbol_ts on signals(symbol, ts);

--- a/src/cli/db.js
+++ b/src/cli/db.js
@@ -1,7 +1,21 @@
 import { spawn } from 'child_process';
+import fs from 'fs';
+import path from 'path';
+import { fileURLToPath } from 'url';
+import { Client } from 'pg';
 
 export async function dbInit() {
-  console.log('initialize database');
+  const __dirname = path.dirname(fileURLToPath(import.meta.url));
+  const sqlPath = path.resolve(__dirname, '../../migrations/db.init.sql');
+  const sql = fs.readFileSync(sqlPath, 'utf8');
+  const client = new Client();
+  await client.connect();
+  try {
+    await client.query(sql);
+    console.log('database initialized');
+  } finally {
+    await client.end();
+  }
 }
 
 export async function dbMigrate() {


### PR DESCRIPTION
## Summary
- add `migrations/db.init.sql` with tables and indexes based on project spec
- implement `dbInit` CLI command to execute init SQL via pg client

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c1440ff3388325afdb2eb57402ea63