### PR TITLE
Add ranged klines fetching with resume support

### DIFF
--- a/bin/cs
+++ b/bin/cs
@@ -14,7 +14,15 @@ program
 
 program.command('db:init').action(dbInit);
 program.command('db:migrate').action(dbMigrate);
-program.command('fetch:klines').requiredOption('--symbol <symbol>').action(fetchKlines);
+program
+  .command('fetch:klines')
+  .requiredOption('--symbol <symbol>')
+  .option('--from <ms>')
+  .option('--to <ms>')
+  .option('--interval <interval>', '1m')
+  .option('--limit <number>', '1000')
+  .option('--resume')
+  .action(fetchKlines);
 program.command('compute:indicators').action(computeIndicators);
 program.command('detect:patterns').action(detectPatterns);
 program.command('signals:generate').action(signalsGenerate);

--- a/src/cli/fetch.js
+++ b/src/cli/fetch.js
@@ -1,9 +1,16 @@
-import { fetchKlinesResume } from '../core/binance.js';
-import { insertCandles } from '../storage/repos/candles.js';
+import { fetchKlinesRange } from '../core/binance.js';
 
 export async function fetchKlines(opts) {
-  const { symbol } = opts;
-  const data = await fetchKlinesResume({ symbol });
-  await insertCandles(symbol, data);
-  console.log(`fetched ${data.length} candles`);
+  const { symbol, from, to, interval = '1m', limit = 1000, resume } = opts;
+  const startMs = from ? Number(from) : undefined;
+  const endMs = to ? Number(to) : undefined;
+  const count = await fetchKlinesRange({
+    symbol,
+    interval,
+    startMs,
+    endMs,
+    limit: Number(limit),
+    resume
+  });
+  console.log(`fetched ${count} candles`);
 }

--- a/test/integration/fetch-range.test.js
+++ b/test/integration/fetch-range.test.js
@@ -1,0 +1,51 @@
+import { jest } from '@jest/globals';
+
+const fetchMock = jest.fn(async url => {
+  const u = new URL(url);
+  const start = Number(u.searchParams.get('startTime') || 0);
+  const end = Number(u.searchParams.get('endTime'));
+  const limit = Number(u.searchParams.get('limit'));
+  const candles = [];
+  for (let t = start; (!end || t < end) && candles.length < limit; t += 60_000) {
+    candles.push([t, '1', '1', '1', '1', '1']);
+  }
+  return { ok: true, json: async () => candles };
+});
+
+jest.unstable_mockModule('node-fetch', () => ({ default: fetchMock }));
+const insertMock = jest.fn(async () => {});
+jest.unstable_mockModule('../../src/storage/repos/candles.js', () => ({ insertCandles: insertMock }));
+const db = { query: jest.fn(async () => []) };
+jest.unstable_mockModule('../../src/storage/db.js', () => db);
+
+const { fetchKlinesRange } = await import('../../src/core/binance.js');
+
+test('fetch range in batches', async () => {
+  fetchMock.mockClear();
+  insertMock.mockClear();
+  await fetchKlinesRange({
+    symbol: 'BTCUSDT',
+    interval: '1m',
+    startMs: 0,
+    endMs: 1_500 * 60_000,
+    limit: 1000
+  });
+  expect(fetchMock).toHaveBeenCalledTimes(2);
+  expect(insertMock).toHaveBeenCalledTimes(2);
+});
+
+test('resume from last stored candle', async () => {
+  fetchMock.mockClear();
+  insertMock.mockClear();
+  db.query.mockResolvedValueOnce([{ m: 60_000 }]);
+  await fetchKlinesRange({
+    symbol: 'BTCUSDT',
+    interval: '1m',
+    endMs: 180_000,
+    resume: true
+  });
+  const url = new URL(fetchMock.mock.calls[0][0]);
+  expect(url.searchParams.get('startTime')).toBe('120000');
+  expect(db.query).toHaveBeenCalled();
+});
+


### PR DESCRIPTION
## Summary
- extend CLI and binance client to fetch klines over a given range with batching and resume
- persist each batch and resume from last candle when requested
- add integration tests for range fetching and resume logic

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c14c9667cc83258c68dd0e3ec3d4bd