### PR TITLE
feat: compute and persist indicators

### DIFF
--- a/src/cli/compute.js
+++ b/src/cli/compute.js
@@ -1,3 +1,37 @@
-export async function computeIndicators() {
-  console.log('compute indicators');
+import { query } from '../storage/db.js';
+import { upsertIndicators } from '../storage/repos/indicators.js';
+import { rsi } from '../core/indicators/rsi.js';
+import { atr } from '../core/indicators/atr.js';
+import { aroon } from '../core/indicators/aroon.js';
+import { bollinger } from '../core/indicators/bollinger.js';
+import { trend } from '../core/indicators/trend.js';
+import { hhll } from '../core/indicators/hhll.js';
+
+export async function computeIndicators(opts) {
+  const { symbol } = opts;
+  const candles = await query(
+    'select open_time, open, high, low, close, volume from candles_1m where symbol=$1 order by open_time',
+    [symbol]
+  );
+  const highs = [];
+  const lows = [];
+  const closes = [];
+  const rows = [];
+  for (const c of candles) {
+    highs.push(Number(c.high));
+    lows.push(Number(c.low));
+    closes.push(Number(c.close));
+    const data = {
+      rsi: closes.length >= 15 ? rsi(closes) : null,
+      atr: highs.length >= 15 ? atr(highs, lows, closes) : null,
+      aroon: highs.length >= 25 ? aroon(highs, lows) : null,
+      bollinger: closes.length >= 20 ? bollinger(closes) : null,
+      trend: trend(closes),
+      hhll: hhll(highs, lows),
+    };
+    rows.push({ openTime: c.open_time, data });
+  }
+  await upsertIndicators(symbol, rows);
+  console.log(`computed ${rows.length} indicator rows`);
 }
+

--- a/src/storage/repos/indicators.js
+++ b/src/storage/repos/indicators.js
@@ -1,0 +1,13 @@
+import { query } from '../db.js';
+
+export async function upsertIndicators(symbol, rows) {
+  for (const r of rows) {
+    await query(
+      `insert into indicators_1m (symbol, open_time, data)
+       values ($1,$2,$3)
+       on conflict (symbol, open_time) do update set data=$3`,
+      [symbol, r.openTime, r.data]
+    );
+  }
+}
+

--- a/test/unit/computeIndicators.test.js
+++ b/test/unit/computeIndicators.test.js
@@ -1,0 +1,47 @@
+import { jest } from '@jest/globals';
+import { rsi } from '../../src/core/indicators/rsi.js';
+import { atr } from '../../src/core/indicators/atr.js';
+import { aroon } from '../../src/core/indicators/aroon.js';
+import { bollinger } from '../../src/core/indicators/bollinger.js';
+import { trend } from '../../src/core/indicators/trend.js';
+import { hhll } from '../../src/core/indicators/hhll.js';
+
+const candles = Array.from({ length: 30 }, (_, i) => ({
+  open_time: i + 1,
+  open: i + 1,
+  high: i + 2,
+  low: i,
+  close: i + 1,
+  volume: 1,
+}));
+
+const upserts = [];
+
+jest.unstable_mockModule('../../src/storage/db.js', () => ({
+  query: jest.fn(async (sql, params) => {
+    if (/select/i.test(sql)) return candles;
+    upserts.push({ sql, params });
+    return [];
+  })
+}));
+
+const { computeIndicators } = await import('../../src/cli/compute.js');
+
+test('computeIndicators persists computed values', async () => {
+  await computeIndicators({ symbol: 'TEST' });
+  expect(upserts.length).toBe(candles.length);
+  const data = upserts[upserts.length - 1].params[2];
+  const highs = candles.map(c => c.high);
+  const lows = candles.map(c => c.low);
+  const closes = candles.map(c => c.close);
+  expect(data.rsi).toBeCloseTo(rsi(closes));
+  expect(data.atr).toBeCloseTo(atr(highs, lows, closes));
+  expect(data.aroon).toEqual(aroon(highs, lows));
+  const bb = bollinger(closes);
+  expect(data.bollinger.middle).toBeCloseTo(bb.middle);
+  expect(data.bollinger.upper).toBeCloseTo(bb.upper);
+  expect(data.bollinger.lower).toBeCloseTo(bb.lower);
+  expect(data.trend).toBe(trend(closes));
+  expect(data.hhll).toEqual(hhll(highs, lows));
+});
+

--- a/test/unit/indicators.test.js
+++ b/test/unit/indicators.test.js
@@ -1,6 +1,9 @@
 import { rsi } from '../../src/core/indicators/rsi.js';
 import { trend } from '../../src/core/indicators/trend.js';
 import { hhll } from '../../src/core/indicators/hhll.js';
+import { atr } from '../../src/core/indicators/atr.js';
+import { aroon } from '../../src/core/indicators/aroon.js';
+import { bollinger } from '../../src/core/indicators/bollinger.js';
 
 test('rsi zigzag ~50', () => {
   const closes = Array.from({ length: 30 }, (_, i) => (i % 2 === 0 ? 1 : 2));
@@ -19,3 +22,28 @@ test('hhll', () => {
   expect(res.hh).toBe(true);
   expect(res.ll).toBe(true);
 });
+
+test('atr constant range', () => {
+  const highs = [2, 3, 4, 5];
+  const lows = [0, 1, 2, 3];
+  const closes = [1, 2, 3, 4];
+  const res = atr(highs, lows, closes, 3);
+  expect(res).toBeCloseTo(2);
+});
+
+test('aroon extremes', () => {
+  const highs = [1, 2, 3];
+  const lows = [1, 2, 3];
+  const res = aroon(highs, lows, 3);
+  expect(res.up).toBe(0);
+  expect(res.down).toBe(100);
+});
+
+test('bollinger flat', () => {
+  const closes = Array(20).fill(5);
+  const res = bollinger(closes);
+  expect(res.middle).toBe(5);
+  expect(res.upper).toBe(5);
+  expect(res.lower).toBe(5);
+});
+


### PR DESCRIPTION
## Summary
- compute RSI, ATR, Aroon, Bollinger Bands, trend and HH/HL/LH/LL from recent candles
- upsert indicator snapshots into `indicators_1m`
- add unit tests for indicator formulas and persistence

## Testing
- `npm test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c14ca1b708832588c9134d43ae2618