### PR TITLE
Implement candlestick pattern detection and storage

### DIFF
--- a/src/cli/patterns.js
+++ b/src/cli/patterns.js
@@ -1,3 +1,27 @@
-export async function detectPatterns() {
+import { query } from '../storage/db.js';
+import { bullishEngulfing, bearishEngulfing } from '../core/patterns/engulfing.js';
+import { hammer } from '../core/patterns/hammer.js';
+import { shootingStar } from '../core/patterns/star.js';
+import { upsertPattern } from '../storage/repos/patterns.js';
+
+export async function detectPatterns({ symbol }) {
+  const candles = await query(
+    'select open_time, open, high, low, close from candles_1m where symbol=$1 order by open_time',
+    [symbol]
+  );
+
+  for (let i = 1; i < candles.length; i++) {
+    const prev = candles[i - 1];
+    const curr = candles[i];
+    const data = {};
+    if (bullishEngulfing(prev, curr)) data.bullishEngulfing = true;
+    if (bearishEngulfing(prev, curr)) data.bearishEngulfing = true;
+    if (hammer(curr)) data.hammer = true;
+    if (shootingStar(curr)) data.shootingStar = true;
+    if (Object.keys(data).length > 0) {
+      await upsertPattern(symbol, curr.open_time, data);
+    }
+  }
+
   console.log('detect patterns');
 }

--- a/src/storage/repos/patterns.js
+++ b/src/storage/repos/patterns.js
@@ -1,0 +1,11 @@
+import { query } from '../db.js';
+
+export async function upsertPattern(symbol, openTime, data) {
+  await query(
+    `insert into patterns_1m (symbol, open_time, data)
+     values ($1,$2,$3)
+     on conflict (symbol, open_time)
+     do update set data=$3`,
+    [symbol, openTime, data]
+  );
+}

--- a/test/integration/patterns.test.js
+++ b/test/integration/patterns.test.js
@@ -1,0 +1,28 @@
+import { jest } from '@jest/globals';
+
+const candles = [
+  { open_time: 1, open: 10, high: 12, low: 8, close: 8 },
+  { open_time: 2, open: 7, high: 12, low: 6, close: 11 }
+];
+
+jest.unstable_mockModule('../../src/storage/db.js', () => ({
+  query: jest.fn(async (sql) => {
+    if (sql.includes('from candles_1m')) {
+      return candles;
+    }
+    return [];
+  })
+}));
+
+const db = await import('../../src/storage/db.js');
+const { detectPatterns } = await import('../../src/cli/patterns.js');
+
+test('detect patterns and write to db', async () => {
+  await detectPatterns({ symbol: 'BTCUSDT' });
+  const insertCalls = db.query.mock.calls.filter((c) =>
+    c[0].includes('insert into patterns_1m')
+  );
+  expect(insertCalls.length).toBeGreaterThan(0);
+  const data = insertCalls[0][1][2];
+  expect(data.bullishEngulfing).toBe(true);
+});

--- a/test/unit/patterns.test.js
+++ b/test/unit/patterns.test.js
@@ -1,5 +1,6 @@
-import { bullishEngulfing } from '../../src/core/patterns/engulfing.js';
+import { bullishEngulfing, bearishEngulfing } from '../../src/core/patterns/engulfing.js';
 import { hammer } from '../../src/core/patterns/hammer.js';
+import { shootingStar } from '../../src/core/patterns/star.js';
 
 test('bullish engulfing', () => {
   const c1 = { open: 10, close: 8 };
@@ -7,7 +8,18 @@ test('bullish engulfing', () => {
   expect(bullishEngulfing(c1, c2)).toBe(true);
 });
 
+test('bearish engulfing', () => {
+  const c1 = { open: 8, close: 10 };
+  const c2 = { open: 11, close: 7 };
+  expect(bearishEngulfing(c1, c2)).toBe(true);
+});
+
 test('hammer', () => {
   const c = { open: 10, close: 11, high: 12, low: 8 };
   expect(hammer(c)).toBe(true);
+});
+
+test('shooting star', () => {
+  const c = { open: 10, close: 9, high: 13, low: 8.9 };
+  expect(shootingStar(c)).toBe(true);
 });


### PR DESCRIPTION
## Summary
- add repository helper to upsert detected patterns into `patterns_1m`
- implement CLI command to scan candles for engulfing, hammer, and star patterns
- add unit tests for pattern detectors and integration test for DB writes

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c14ca6221c8325b6d6a60b5cafeafc