### PR TITLE
Implement signal generation and strategy selection

### DIFF
--- a/bin/cs
+++ b/bin/cs
@@ -17,7 +17,12 @@ program.command('db:migrate').action(dbMigrate);
 program.command('fetch:klines').requiredOption('--symbol <symbol>').action(fetchKlines);
 program.command('compute:indicators').action(computeIndicators);
 program.command('detect:patterns').action(detectPatterns);
-program.command('signals:generate').action(signalsGenerate);
+program
+  .command('signals:generate')
+  .requiredOption('--symbol <symbol>')
+  .requiredOption('--interval <interval>')
+  .requiredOption('--strategy <strategy>')
+  .action(signalsGenerate);
 program.command('backtest:run').action(backtestRun);
 
 program.parseAsync(process.argv);

--- a/src/cli/signals.js
+++ b/src/cli/signals.js
@@ -1,3 +1,36 @@
-export async function signalsGenerate() {
-  console.log('generate signals');
+import { query } from '../storage/db.js';
+import { upsertSignals } from '../storage/repos/signals.js';
+import { runStrategy } from '../core/signals/engine.js';
+import SidewaysReversal from '../core/signals/strategies/SidewaysReversal.js';
+import BBRevert from '../core/signals/strategies/BBRevert.js';
+
+const STRATEGIES = {
+  SidewaysReversal,
+  BBRevert,
+};
+
+export async function signalsGenerate(opts) {
+  const { symbol, interval, strategy: strategyName } = opts;
+  const strategy = STRATEGIES[strategyName];
+  if (!strategy) throw new Error(`Unknown strategy: ${strategyName}`);
+
+  const indicators = await query(
+    `select open_time, data from indicators_${interval} where symbol=$1 order by open_time`,
+    [symbol]
+  );
+  const patterns = await query(
+    `select open_time, data from patterns_${interval} where symbol=$1`,
+    [symbol]
+  );
+  const patternMap = new Map(patterns.map(p => [p.open_time, p.data]));
+
+  const signals = [];
+  for (const row of indicators) {
+    const ind = { ...row.data, ...(patternMap.get(row.open_time) || {}) };
+    const sig = runStrategy(strategy, ind);
+    if (sig) signals.push({ openTime: row.open_time, signal: sig });
+  }
+
+  await upsertSignals(symbol, signals);
+  console.log(`generated ${signals.length} signals`);
 }

--- a/src/storage/repos/signals.js
+++ b/src/storage/repos/signals.js
@@ -1,0 +1,14 @@
+import { query } from '../db.js';
+
+export async function upsertSignals(symbol, signals) {
+  for (const s of signals) {
+    await query(
+      `insert into signals (symbol, open_time, signal)
+       values ($1,$2,$3)
+       on conflict (symbol, open_time) do update set signal = excluded.signal`,
+      [symbol, s.openTime, s.signal]
+    );
+  }
+}
+
+export default { upsertSignals };

--- a/test/unit/signals.test.js
+++ b/test/unit/signals.test.js
@@ -1,0 +1,52 @@
+import { jest } from '@jest/globals';
+
+const queryMock = jest.fn();
+const upsertMock = jest.fn();
+
+await jest.unstable_mockModule('../../src/storage/db.js', () => ({
+  query: queryMock,
+}));
+await jest.unstable_mockModule('../../src/storage/repos/signals.js', () => ({
+  upsertSignals: upsertMock,
+}));
+
+const { signalsGenerate } = await import('../../src/cli/signals.js');
+
+beforeEach(() => {
+  queryMock.mockReset();
+  upsertMock.mockReset();
+});
+
+test('generates signals for SidewaysReversal strategy', async () => {
+  queryMock
+    .mockResolvedValueOnce([
+      { open_time: 1, data: { hhll: { hh: true, ll: false } } },
+      { open_time: 2, data: { hhll: { hh: false, ll: true } } },
+    ])
+    .mockResolvedValueOnce([
+      { open_time: 1, data: {} },
+      { open_time: 2, data: {} },
+    ]);
+  await signalsGenerate({ symbol: 'BTC', interval: '1m', strategy: 'SidewaysReversal' });
+  expect(upsertMock).toHaveBeenCalledWith('BTC', [
+    { openTime: 1, signal: 'buy' },
+    { openTime: 2, signal: 'sell' },
+  ]);
+});
+
+test('generates signals for BBRevert strategy', async () => {
+  queryMock
+    .mockResolvedValueOnce([
+      { open_time: 1, data: { price: 90, bbands: { lower: 100, upper: 110 } } },
+      { open_time: 2, data: { price: 120, bbands: { lower: 100, upper: 110 } } },
+    ])
+    .mockResolvedValueOnce([
+      { open_time: 1, data: {} },
+      { open_time: 2, data: {} },
+    ]);
+  await signalsGenerate({ symbol: 'ETH', interval: '1m', strategy: 'BBRevert' });
+  expect(upsertMock).toHaveBeenCalledWith('ETH', [
+    { openTime: 1, signal: 'buy' },
+    { openTime: 2, signal: 'sell' },
+  ]);
+});


### PR DESCRIPTION
## Summary
- add signals repository for upserting generated signals
- implement `signals:generate` CLI to load data, run strategies, and store signals
- support `--strategy` option in CLI command
- add tests for signal generation for SidewaysReversal and BBRevert

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68c14caba674832583abbbda82bb1583