### PR TITLE
Refactor SidewaysReversal strategy and extend tests

### DIFF
--- a/src/core/signals/strategies/SidewaysReversal.js
+++ b/src/core/signals/strategies/SidewaysReversal.js
@@ -1,13 +1,17 @@
 export default {
   name: 'SidewaysReversal',
   entry(ind) {
-    if (ind.hhll?.hh && !ind.hhll?.ll) {
+    const sideways = ind.trend === 'sideways';
+    const oversold = typeof ind.rsi === 'number' && ind.rsi <= 30;
+    if (sideways && oversold && ind.bullishEngulfing) {
       return 'buy';
     }
     return null;
   },
   exit(ind) {
-    if (ind.hhll?.ll) {
+    const notSideways = ind.trend !== 'sideways';
+    const overbought = typeof ind.rsi === 'number' && ind.rsi >= 70;
+    if (notSideways || overbought || ind.bearishEngulfing) {
       return 'sell';
     }
     return null;

--- a/test/unit/engine.test.js
+++ b/test/unit/engine.test.js
@@ -2,7 +2,7 @@ import { runStrategy } from '../../src/core/signals/engine.js';
 import SidewaysReversal from '../../src/core/signals/strategies/SidewaysReversal.js';
 
 test('runStrategy returns buy', () => {
-  const ind = { trend: 'flat', hhll: { hh: true, ll: false } };
+  const ind = { trend: 'sideways', rsi: 20, bullishEngulfing: true };
   const sig = runStrategy(SidewaysReversal, ind);
   expect(sig).toBe('buy');
 });

--- a/test/unit/signals.test.js
+++ b/test/unit/signals.test.js
@@ -20,12 +20,12 @@ beforeEach(() => {
 test('generates signals for SidewaysReversal strategy', async () => {
   queryMock
     .mockResolvedValueOnce([
-      { open_time: 1, data: { hhll: { hh: true, ll: false } } },
-      { open_time: 2, data: { hhll: { hh: false, ll: true } } },
+      { open_time: 1, data: { trend: 'sideways', rsi: 25 } },
+      { open_time: 2, data: { trend: 'sideways', rsi: 50 } },
     ])
     .mockResolvedValueOnce([
-      { open_time: 1, data: {} },
-      { open_time: 2, data: {} },
+      { open_time: 1, data: { bullishEngulfing: true } },
+      { open_time: 2, data: { bearishEngulfing: true } },
     ]);
   await signalsGenerate({ symbol: 'BTC', interval: '1m', strategy: 'SidewaysReversal' });
   expect(upsertMock).toHaveBeenCalledWith('BTC', [

--- a/test/unit/signals/SidewaysReversal.test.js
+++ b/test/unit/signals/SidewaysReversal.test.js
@@ -1,0 +1,24 @@
+import { runStrategy } from '../../../src/core/signals/engine.js';
+import SidewaysReversal from '../../../src/core/signals/strategies/SidewaysReversal.js';
+
+describe('SidewaysReversal strategy', () => {
+  test('returns buy on sideways trend, oversold RSI and bullish engulfing', () => {
+    const ind = { trend: 'sideways', rsi: 20, bullishEngulfing: true };
+    expect(runStrategy(SidewaysReversal, ind)).toBe('buy');
+  });
+
+  test('returns sell on overbought RSI', () => {
+    const ind = { trend: 'sideways', rsi: 75 };
+    expect(runStrategy(SidewaysReversal, ind)).toBe('sell');
+  });
+
+  test('returns sell on bearish engulfing pattern', () => {
+    const ind = { trend: 'sideways', rsi: 40, bearishEngulfing: true };
+    expect(runStrategy(SidewaysReversal, ind)).toBe('sell');
+  });
+
+  test('returns sell when trend breaks sideways', () => {
+    const ind = { trend: 'up', rsi: 40 };
+    expect(runStrategy(SidewaysReversal, ind)).toBe('sell');
+  });
+});


### PR DESCRIPTION
## Summary
- Replace HH/LL logic in SidewaysReversal with trend/RSI and engulfing pattern checks
- Merge candlestick pattern data with indicators when generating signals
- Add unit tests for SidewaysReversal strategy and update signal generation tests

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c165f001808325b1eccedabcb31d5a