### PR TITLE
Refactor trend indicator to use Bollinger and Aroon data

### DIFF
--- a/src/cli/compute.js
+++ b/src/cli/compute.js
@@ -21,12 +21,14 @@ export async function computeIndicators(opts) {
     highs.push(Number(c.high));
     lows.push(Number(c.low));
     closes.push(Number(c.close));
+    const a = highs.length >= 25 ? aroon(highs, lows) : null;
+    const bb = closes.length >= 20 ? bollinger(closes) : null;
     const data = {
       rsi: closes.length >= 15 ? rsi(closes) : null,
       atr: highs.length >= 15 ? atr(highs, lows, closes) : null,
-      aroon: highs.length >= 25 ? aroon(highs, lows) : null,
-      bollinger: closes.length >= 20 ? bollinger(closes) : null,
-      trend: trend(closes),
+      aroon: a,
+      bollinger: bb,
+      trend: trend(closes[closes.length - 1], bb?.middle, a?.up, a?.down),
       hhll: hhll(highs, lows),
     };
     rows.push({ openTime: c.open_time, data });

--- a/src/core/indicators/trend.js
+++ b/src/core/indicators/trend.js
@@ -1,8 +1,6 @@
-export function trend(closes) {
-  if (closes.length < 2) return 'flat';
-  const first = closes[0];
-  const last = closes[closes.length - 1];
-  if (last > first) return 'up';
-  if (last < first) return 'down';
-  return 'flat';
+export function trend(close, bbMid, aroonUp, aroonDown) {
+  if (bbMid == null || aroonUp == null || aroonDown == null) return 'range';
+  if (close > bbMid && aroonUp > aroonDown + 20) return 'up';
+  if (close < bbMid && aroonDown > aroonUp + 20) return 'down';
+  return 'range';
 }

--- a/src/core/signals/strategies/BBRevert.js
+++ b/src/core/signals/strategies/BBRevert.js
@@ -2,6 +2,6 @@ export default {
   name: 'BBRevert',
   rules: [
     { when: i => i.close < i.bbands.lower, signal: 'buy' },
-    { when: i => i.close > i.bbands.upper, signal: 'sell' }
+    { when: i => i.close > i.bbands.upper || i.rsi > 70, signal: 'sell' }
   ]
 };

--- a/src/core/signals/strategies/SidewaysReversal.js
+++ b/src/core/signals/strategies/SidewaysReversal.js
@@ -1,7 +1,7 @@
 export default {
   name: 'SidewaysReversal',
   entry(ind) {
-    const sideways = ind.trend === 'sideways';
+    const sideways = ind.trend === 'range';
     const oversold = typeof ind.rsi === 'number' && ind.rsi <= 30;
     if (sideways && oversold && ind.bullishEngulfing) {
       return 'buy';
@@ -9,7 +9,7 @@ export default {
     return null;
   },
   exit(ind) {
-    const notSideways = ind.trend !== 'sideways';
+    const notSideways = ind.trend !== 'range';
     const overbought = typeof ind.rsi === 'number' && ind.rsi >= 70;
     if (notSideways || overbought || ind.bearishEngulfing) {
       return 'sell';

--- a/test/integration/strategies.test.js
+++ b/test/integration/strategies.test.js
@@ -22,13 +22,13 @@ describe('signals generation and backtest integration', () => {
   test('SidewaysReversal generates signals and backtest produces trades', async () => {
     queryMock
       .mockResolvedValueOnce([
-        { open_time: 1, data: { hhll: { hh: false, ll: false } } },
-        { open_time: 2, data: { hhll: { hh: true, ll: false } } },
-        { open_time: 3, data: { hhll: { hh: false, ll: true } } },
+        { open_time: 1, data: { trend: 'range', rsi: 40 }, close: 100 },
+        { open_time: 2, data: { trend: 'range', rsi: 20 }, close: 100 },
+        { open_time: 3, data: { trend: 'up', rsi: 40 }, close: 100 },
       ])
       .mockResolvedValueOnce([
         { open_time: 1, data: {} },
-        { open_time: 2, data: {} },
+        { open_time: 2, data: { bullishEngulfing: true } },
         { open_time: 3, data: {} },
       ]);
 
@@ -65,9 +65,9 @@ describe('signals generation and backtest integration', () => {
   test('BBRevert generates signals and backtest produces trades', async () => {
     queryMock
       .mockResolvedValueOnce([
-        { open_time: 1, data: { price: 100, bbands: { lower: 90, upper: 110 } } },
-        { open_time: 2, data: { price: 80, bbands: { lower: 90, upper: 110 } } },
-        { open_time: 3, data: { price: 120, bbands: { lower: 90, upper: 110 } } },
+        { open_time: 1, data: { bbands: { lower: 90, upper: 110 } }, close: 100 },
+        { open_time: 2, data: { bbands: { lower: 90, upper: 110 } }, close: 80 },
+        { open_time: 3, data: { bbands: { lower: 90, upper: 110 } }, close: 120 },
       ])
       .mockResolvedValueOnce([
         { open_time: 1, data: {} },

--- a/test/unit/computeIndicators.test.js
+++ b/test/unit/computeIndicators.test.js
@@ -34,14 +34,15 @@ test('computeIndicators persists computed values', async () => {
   const highs = candles.map(c => c.high);
   const lows = candles.map(c => c.low);
   const closes = candles.map(c => c.close);
+  const a = aroon(highs, lows);
+  const bb = bollinger(closes);
   expect(data.rsi).toBeCloseTo(rsi(closes));
   expect(data.atr).toBeCloseTo(atr(highs, lows, closes));
-  expect(data.aroon).toEqual(aroon(highs, lows));
-  const bb = bollinger(closes);
+  expect(data.aroon).toEqual(a);
   expect(data.bollinger.middle).toBeCloseTo(bb.middle);
   expect(data.bollinger.upper).toBeCloseTo(bb.upper);
   expect(data.bollinger.lower).toBeCloseTo(bb.lower);
-  expect(data.trend).toBe(trend(closes));
+  expect(data.trend).toBe(trend(closes[closes.length - 1], bb.middle, a.up, a.down));
   expect(data.hhll).toEqual(hhll(highs, lows));
 });
 

--- a/test/unit/engine.test.js
+++ b/test/unit/engine.test.js
@@ -2,7 +2,7 @@ import { runStrategy } from '../../src/core/signals/engine.js';
 import SidewaysReversal from '../../src/core/signals/strategies/SidewaysReversal.js';
 
 test('runStrategy returns buy', () => {
-  const ind = { trend: 'sideways', rsi: 20, bullishEngulfing: true };
+  const ind = { trend: 'range', rsi: 20, bullishEngulfing: true };
   const sig = runStrategy(SidewaysReversal, ind);
   expect(sig).toBe('buy');
 });

--- a/test/unit/indicators.test.js
+++ b/test/unit/indicators.test.js
@@ -12,9 +12,10 @@ test('rsi zigzag ~50', () => {
   expect(rsiVal).toBeLessThan(60);
 });
 
-test('trend up/down', () => {
-  expect(trend([1, 2])).toBe('up');
-  expect(trend([2, 1])).toBe('down');
+test('trend up/down/range', () => {
+  expect(trend(110, 100, 80, 50)).toBe('up');
+  expect(trend(90, 100, 30, 70)).toBe('down');
+  expect(trend(100, 100, 50, 50)).toBe('range');
 });
 
 test('hhll', () => {

--- a/test/unit/signals.test.js
+++ b/test/unit/signals.test.js
@@ -20,8 +20,8 @@ beforeEach(() => {
 test('generates signals for SidewaysReversal strategy', async () => {
   queryMock
     .mockResolvedValueOnce([
-      { open_time: 1, data: { hhll: { hh: true, ll: false } }, close: 0 },
-      { open_time: 2, data: { hhll: { hh: false, ll: true } }, close: 0 },
+      { open_time: 1, data: { trend: 'range', rsi: 20 }, close: 0 },
+      { open_time: 2, data: { trend: 'range', rsi: 50 }, close: 0 },
     ])
     .mockResolvedValueOnce([
       { open_time: 1, data: { bullishEngulfing: true } },

--- a/test/unit/signals/BBRevert.test.js
+++ b/test/unit/signals/BBRevert.test.js
@@ -4,7 +4,7 @@ import BBRevert from '../../../src/core/signals/strategies/BBRevert.js';
 test('entry returns buy when conditions met', () => {
   const ind = {
     close: 90,
-    bollinger: { lower: 100, upper: 110 },
+    bbands: { lower: 100, upper: 110 },
     aroon: { up: 60 },
     rsi: 50,
   };
@@ -15,7 +15,7 @@ test('entry returns buy when conditions met', () => {
 test('exit returns sell when close above upper band', () => {
   const ind = {
     close: 120,
-    bollinger: { lower: 100, upper: 110 },
+    bbands: { lower: 100, upper: 110 },
     aroon: { up: 40 },
     rsi: 50,
   };
@@ -26,7 +26,7 @@ test('exit returns sell when close above upper band', () => {
 test('exit returns sell when rsi above 70', () => {
   const ind = {
     close: 105,
-    bollinger: { lower: 100, upper: 110 },
+    bbands: { lower: 100, upper: 110 },
     aroon: { up: 40 },
     rsi: 80,
   };

--- a/test/unit/signals/SidewaysReversal.test.js
+++ b/test/unit/signals/SidewaysReversal.test.js
@@ -2,22 +2,22 @@ import { runStrategy } from '../../../src/core/signals/engine.js';
 import SidewaysReversal from '../../../src/core/signals/strategies/SidewaysReversal.js';
 
 describe('SidewaysReversal strategy', () => {
-  test('returns buy on sideways trend, oversold RSI and bullish engulfing', () => {
-    const ind = { trend: 'sideways', rsi: 20, bullishEngulfing: true };
+  test('returns buy on range trend, oversold RSI and bullish engulfing', () => {
+    const ind = { trend: 'range', rsi: 20, bullishEngulfing: true };
     expect(runStrategy(SidewaysReversal, ind)).toBe('buy');
   });
 
   test('returns sell on overbought RSI', () => {
-    const ind = { trend: 'sideways', rsi: 75 };
+    const ind = { trend: 'range', rsi: 75 };
     expect(runStrategy(SidewaysReversal, ind)).toBe('sell');
   });
 
   test('returns sell on bearish engulfing pattern', () => {
-    const ind = { trend: 'sideways', rsi: 40, bearishEngulfing: true };
+    const ind = { trend: 'range', rsi: 40, bearishEngulfing: true };
     expect(runStrategy(SidewaysReversal, ind)).toBe('sell');
   });
 
-  test('returns sell when trend breaks sideways', () => {
+  test('returns sell when trend breaks range', () => {
     const ind = { trend: 'up', rsi: 40 };
     expect(runStrategy(SidewaysReversal, ind)).toBe('sell');
   });


### PR DESCRIPTION
## Summary
- Reworked `trend` indicator to derive direction from latest close, Bollinger middle band, and Aroon up/down values
- Updated indicator computation to feed Bollinger/Aroon results into the new trend logic and adjusted signal strategies
- Expanded unit and integration tests for indicators, strategy logic, and signal generation

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c1a41f49488325af30b3c3fadb6907