### PR TITLE
feat: allow configurable pattern thresholds

### DIFF
--- a/src/cli/patterns.js
+++ b/src/cli/patterns.js
@@ -4,7 +4,11 @@ import { hammer } from '../core/patterns/hammer.js';
 import { shootingStar } from '../core/patterns/star.js';
 import { upsertPattern } from '../storage/repos/patterns.js';
 
-export async function detectPatterns({ symbol }) {
+export async function detectPatterns({
+  symbol,
+  hammer: hammerOptions = {},
+  star: starOptions = {},
+} = {}) {
   const candles = await query(
     'select open_time, open, high, low, close from candles_1m where symbol=$1 order by open_time',
     [symbol]
@@ -16,8 +20,8 @@ export async function detectPatterns({ symbol }) {
     const data = {};
     if (bullishEngulfing(prev, curr)) data.bullishEngulfing = true;
     if (bearishEngulfing(prev, curr)) data.bearishEngulfing = true;
-    if (hammer(curr)) data.hammer = true;
-    if (shootingStar(curr)) data.shootingStar = true;
+    if (hammer(curr, hammerOptions)) data.hammer = true;
+    if (shootingStar(curr, starOptions)) data.shootingStar = true;
     if (Object.keys(data).length > 0) {
       await upsertPattern(symbol, curr.open_time, data);
     }

--- a/src/core/patterns/hammer.js
+++ b/src/core/patterns/hammer.js
@@ -1,6 +1,12 @@
-export function hammer(c) {
+export function hammer(
+  c,
+  { lowerMultiplier = 2, upperMultiplier = 1 } = {}
+) {
   const body = Math.abs(c.close - c.open);
   const lowerWick = Math.min(c.open, c.close) - c.low;
   const upperWick = c.high - Math.max(c.open, c.close);
-  return lowerWick >= 2 * body && upperWick <= body;
+  return (
+    lowerWick >= lowerMultiplier * body &&
+    upperWick <= upperMultiplier * body
+  );
 }

--- a/src/core/patterns/star.js
+++ b/src/core/patterns/star.js
@@ -1,6 +1,12 @@
-export function shootingStar(c) {
+export function shootingStar(
+  c,
+  { upperMultiplier = 2, lowerMultiplier = 0.3 } = {}
+) {
   const body = Math.abs(c.close - c.open);
   const upper = c.high - Math.max(c.open, c.close);
   const lower = Math.min(c.open, c.close) - c.low;
-  return upper >= body * 2 && lower <= body * 0.3;
+  return (
+    upper >= body * upperMultiplier &&
+    lower <= body * lowerMultiplier
+  );
 }

--- a/test/unit/patterns.test.js
+++ b/test/unit/patterns.test.js
@@ -19,7 +19,17 @@ test('hammer', () => {
   expect(hammer(c)).toBe(true);
 });
 
+test('hammer with custom ratios', () => {
+  const c = { open: 10, close: 11, high: 12, low: 8 };
+  expect(hammer(c, { lowerMultiplier: 3 })).toBe(false);
+});
+
 test('shooting star', () => {
   const c = { open: 10, close: 9, high: 13, low: 8.9 };
   expect(shootingStar(c)).toBe(true);
+});
+
+test('shooting star with custom ratios', () => {
+  const c = { open: 10, close: 9, high: 13, low: 8.9 };
+  expect(shootingStar(c, { upperMultiplier: 4 })).toBe(false);
 });


### PR DESCRIPTION
## Summary
- add options to hammer and shooting star pattern detectors
- allow CLI pattern detection to accept custom threshold options
- test hammer and shooting star with custom ratios

## Testing
- `npm test` *(fails: signals and strategy tests fail)*
- `npm run lint` *(fails: no-unused-vars in src/cli/backtest.js)*

------
https://chatgpt.com/codex/tasks/task_e_68c1aa4b5d208325a4c158cd3e66d538