### PR TITLE
Add initial candle pattern upsert

### DIFF
--- a/src/cli/patterns.js
+++ b/src/cli/patterns.js
@@ -14,6 +14,15 @@ export async function detectPatterns({
     [symbol]
   );
 
+  if (candles.length > 0) {
+    await upsertPatterns(symbol, candles[0].open_time, {
+      bullishEngulfing: false,
+      bearishEngulfing: false,
+      hammer: false,
+      shootingStar: false,
+    });
+  }
+
   for (let i = 1; i < candles.length; i++) {
     const prev = candles[i - 1];
     const curr = candles[i];

--- a/test/integration/patterns.test.js
+++ b/test/integration/patterns.test.js
@@ -23,7 +23,7 @@ test('detect patterns and write to db', async () => {
   const insertCalls = db.query.mock.calls.filter((c) =>
     c[0].includes('insert into patterns_1m')
   );
-  expect(insertCalls).toHaveLength(2);
-  const callNoPattern = insertCalls.find((c) => c[1][1] === 3);
-  expect(callNoPattern[1].slice(2)).toEqual([false, false, false, false]);
+  expect(insertCalls).toHaveLength(candles.length);
+  const firstCall = insertCalls.find((c) => c[1][1] === candles[0].open_time);
+  expect(firstCall[1].slice(2)).toEqual([false, false, false, false]);
 });


### PR DESCRIPTION
## Summary
- record neutral pattern for first candle before detecting others
- adjust pattern integration test to expect an entry per candle

## Testing
- `npm test` *(fails: test/unit/signals.test.js, test/integration/strategies.test.js, test/unit/signals/BBRevert.test.js)*

------
https://chatgpt.com/codex/tasks/task_e_68c1b047f2f88325a0a0e4a04946d950