### PR TITLE
feat: sync timestamps with binance server

### DIFF
--- a/bin/cs
+++ b/bin/cs
@@ -22,6 +22,7 @@ program
   .option('--interval <interval>', '1m')
   .option('--limit <number>', '1000')
   .option('--resume')
+  .option('--server-time')
   .action(fetchKlines);
 program.command('compute:indicators').action(computeIndicators);
 program.command('detect:patterns').action(detectPatterns);

--- a/src/cli/fetch.js
+++ b/src/cli/fetch.js
@@ -1,9 +1,15 @@
-import { fetchKlinesRange } from '../core/binance.js';
+import { fetchKlinesRange, getServerTime } from '../core/binance.js';
 
 export async function fetchKlines(opts) {
-  const { symbol, from, to, interval = '1m', limit = 1000, resume } = opts;
-  const startMs = from ? Number(from) : undefined;
-  const endMs = to ? Number(to) : undefined;
+  const { symbol, from, to, interval = '1m', limit = 1000, resume, serverTime } = opts;
+  let startMs = from ? Number(from) : undefined;
+  let endMs = to ? Number(to) : undefined;
+  if (serverTime) {
+    const serverMs = await getServerTime();
+    const offset = serverMs - Date.now();
+    if (startMs !== undefined) startMs += offset;
+    if (endMs !== undefined) endMs += offset;
+  }
   const count = await fetchKlinesRange({
     symbol,
     interval,

--- a/src/core/binance.js
+++ b/src/core/binance.js
@@ -12,6 +12,15 @@ async function rateLimit() {
   lastCall = Date.now();
 }
 
+export async function getServerTime() {
+  await rateLimit();
+  const url = new URL('/api/v3/time', BASE);
+  const res = await fetch(url);
+  if (!res.ok) throw new Error('binance error');
+  const data = await res.json();
+  return data.serverTime;
+}
+
 export async function fetchKlines({ symbol, interval, startMs, endMs, limit = 1000 }) {
   await rateLimit();
   const url = new URL('/api/v3/klines', BASE);

--- a/test/unit/server-time.test.js
+++ b/test/unit/server-time.test.js
@@ -1,0 +1,41 @@
+import { jest } from '@jest/globals';
+
+const fetchMock = jest.fn(async url => {
+  if (url.toString().endsWith('/api/v3/time')) {
+    return { ok: true, json: async () => ({ serverTime: 2000 }) };
+  }
+  throw new Error(`Unexpected URL: ${url}`);
+});
+
+jest.unstable_mockModule('node-fetch', () => ({ default: fetchMock }));
+
+jest.unstable_mockModule('../../src/core/binance.js', async () => {
+  const { default: fetch } = await import('node-fetch');
+  return {
+    fetchKlinesRange: jest.fn(),
+    getServerTime: async () => {
+      const url = new URL('/api/v3/time', 'https://api.binance.com');
+      const res = await fetch(url);
+      if (!res.ok) throw new Error('binance error');
+      const data = await res.json();
+      return data.serverTime;
+    }
+  };
+});
+
+const { fetchKlines } = await import('../../src/cli/fetch.js');
+const { fetchKlinesRange } = await import('../../src/core/binance.js');
+
+test('fetchKlines adjusts times using server time', async () => {
+  const nowSpy = jest.spyOn(Date, 'now').mockReturnValue(1000);
+  await fetchKlines({ symbol: 'TEST', from: '0', to: '100', serverTime: true });
+  expect(fetchKlinesRange).toHaveBeenCalledWith({
+    symbol: 'TEST',
+    interval: '1m',
+    startMs: 1000,
+    endMs: 1100,
+    limit: 1000,
+    resume: undefined
+  });
+  nowSpy.mockRestore();
+});


### PR DESCRIPTION
## Summary
- add `getServerTime` helper for Binance API
- allow `fetch:klines` to sync timestamps with server via `--server-time`
- test server time offset handling

## Testing
- `npm test` *(fails: signals tests)*
- `npm test test/unit/server-time.test.js`


------
https://chatgpt.com/codex/tasks/task_e_68c1b2f5fc088325bcbfd420a8259e31