### PR TITLE
Add getServerTime import to fetch CLI

### DIFF
--- a/src/cli/fetch.js
+++ b/src/cli/fetch.js
@@ -1,4 +1,4 @@
-import { fetchKlinesRange, fetchServerTime } from '../core/binance.js';
+import { fetchKlinesRange, fetchServerTime, getServerTime } from '../core/binance.js';
 import logger from '../utils/logger.js';
 
 export async function fetchKlines(opts) {

--- a/test/unit/server-time.test.js
+++ b/test/unit/server-time.test.js
@@ -19,7 +19,8 @@ jest.unstable_mockModule('../../src/core/binance.js', async () => {
       if (!res.ok) throw new Error('binance error');
       const data = await res.json();
       return data.serverTime;
-    }
+    },
+    getServerTime: jest.fn(() => Date.now())
   };
 });
 


### PR DESCRIPTION
## Summary
- include getServerTime in `src/cli/fetch.js` imports
- mock new import in server time unit test

## Testing
- `npm test test/unit/server-time.test.js`


------
https://chatgpt.com/codex/tasks/task_e_68c1ccfd7c448325b8e727f1168b4750