### PR TITLE
Add CLI fetch resume flag tests

### DIFF
--- a/src/cli/fetch.js
+++ b/src/cli/fetch.js
@@ -2,7 +2,7 @@ import { fetchKlinesRange, fetchServerTime, getServerTime } from '../core/binanc
 import logger from '../utils/logger.js';
 
 export async function fetchKlines(opts) {
-  const { symbol, from, to, interval = '1m', limit = 1000, resume, serverTime } = opts;
+  const { symbol, from, to, interval = '1m', limit = 1000, resume = false, serverTime } = opts;
   let startMs = from ? Number(from) : undefined;
   let endMs = to ? Number(to) : undefined;
   if (serverTime) {

--- a/test/unit/fetch-cli-resume.test.js
+++ b/test/unit/fetch-cli-resume.test.js
@@ -1,0 +1,39 @@
+import { jest } from '@jest/globals';
+
+const fetchKlinesRange = jest.fn(async () => 0);
+
+jest.unstable_mockModule('../../src/core/binance.js', () => ({
+  fetchKlinesRange,
+  fetchServerTime: jest.fn(),
+  getServerTime: jest.fn()
+}));
+
+const { fetchKlines } = await import('../../src/cli/fetch.js');
+
+beforeEach(() => {
+  fetchKlinesRange.mockClear();
+});
+
+test('passes resume flag when provided', async () => {
+  await fetchKlines({ symbol: 'TEST', resume: true });
+  expect(fetchKlinesRange).toHaveBeenCalledWith({
+    symbol: 'TEST',
+    interval: '1m',
+    startMs: undefined,
+    endMs: undefined,
+    limit: 1000,
+    resume: true
+  });
+});
+
+test('defaults resume to false when omitted', async () => {
+  await fetchKlines({ symbol: 'TEST' });
+  expect(fetchKlinesRange).toHaveBeenCalledWith({
+    symbol: 'TEST',
+    interval: '1m',
+    startMs: undefined,
+    endMs: undefined,
+    limit: 1000,
+    resume: false
+  });
+});

--- a/test/unit/server-time.test.js
+++ b/test/unit/server-time.test.js
@@ -36,7 +36,7 @@ test('fetchKlines adjusts times using server time', async () => {
     startMs: 1000,
     endMs: 1100,
     limit: 1000,
-    resume: undefined
+    resume: false
   });
   nowSpy.mockRestore();
 });


### PR DESCRIPTION
## Summary
- default `resume` flag to `false` in CLI fetch
- add tests verifying `resume` flag forwarding and default behavior

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68c1d3bcb5a4832592be1f411e785248