### PR TITLE
Add rolling-window helper for incremental indicators

### DIFF
--- a/src/core/indicators/aroon.js
+++ b/src/core/indicators/aroon.js
@@ -1,10 +1,18 @@
+import { RollingWindow } from '../../utils/math.js';
+
 export function aroon(highs, lows, period = 25) {
   if (highs.length < period) return null;
-  const sliceH = highs.slice(-period);
-  const sliceL = lows.slice(-period);
-  const highIndex = sliceH.lastIndexOf(Math.max(...sliceH));
-  const lowIndex = sliceL.lastIndexOf(Math.min(...sliceL));
-  const up = ((period - 1 - highIndex) / (period - 1)) * 100;
-  const down = ((period - 1 - lowIndex) / (period - 1)) * 100;
+
+  const highWindow = new RollingWindow(period);
+  const lowWindow = new RollingWindow(period);
+
+  for (let i = 0; i < highs.length; i++) {
+    highWindow.push(highs[i]);
+    lowWindow.push(lows[i]);
+  }
+
+  const up = (highWindow.maxAge() / (period - 1)) * 100;
+  const down = (lowWindow.minAge() / (period - 1)) * 100;
+
   return { up, down };
 }

--- a/src/core/indicators/atr.js
+++ b/src/core/indicators/atr.js
@@ -1,12 +1,13 @@
+import { RollingWindow } from '../../utils/math.js';
+
 export function atr(highs, lows, closes, period = 14) {
   if (highs.length < period + 1) return null;
-  let trs = [];
+  const window = new RollingWindow(period);
   for (let i = 1; i < highs.length; i++) {
     const hl = highs[i] - lows[i];
     const hc = Math.abs(highs[i] - closes[i - 1]);
     const lc = Math.abs(lows[i] - closes[i - 1]);
-    trs.push(Math.max(hl, hc, lc));
+    window.push(Math.max(hl, hc, lc));
   }
-  trs = trs.slice(-period);
-  return trs.reduce((a, b) => a + b, 0) / period;
+  return window.avg();
 }

--- a/src/core/indicators/bollinger.js
+++ b/src/core/indicators/bollinger.js
@@ -1,8 +1,10 @@
+import { RollingWindow } from '../../utils/math.js';
+
 export function bollinger(closes, period = 20, mult = 2) {
   if (closes.length < period) return null;
-  const slice = closes.slice(-period);
-  const mean = slice.reduce((a, b) => a + b, 0) / period;
-  const variance = slice.reduce((a, b) => a + Math.pow(b - mean, 2), 0) / period;
-  const std = Math.sqrt(variance);
+  const window = new RollingWindow(period);
+  for (const c of closes) window.push(c);
+  const mean = window.avg();
+  const std = window.std();
   return { middle: mean, upper: mean + mult * std, lower: mean - mult * std };
 }

--- a/src/utils/math.js
+++ b/src/utils/math.js
@@ -21,3 +21,80 @@ export function rolling(values, window, fn) {
   }
   return result;
 }
+
+// Stateful rolling window helper maintaining running sum, sum of squares,
+// and tracking min/max values with their ages. This allows indicators such
+// as SMA, ATR, Aroon and Bollinger bands to be updated incrementally
+// without slicing arrays on every call.
+export class RollingWindow {
+  constructor(period) {
+    this.period = period;
+    this.values = [];
+    this.sum = 0;
+    this.sumSquares = 0;
+    this.index = 0;
+    this.maxDeque = [];
+    this.minDeque = [];
+  }
+
+  // push a new value into the window
+  push(value) {
+    const idx = this.index++;
+    this.values.push({ value, idx });
+    this.sum += value;
+    this.sumSquares += value * value;
+
+    while (this.maxDeque.length && this.maxDeque[this.maxDeque.length - 1].value <= value) {
+      this.maxDeque.pop();
+    }
+    this.maxDeque.push({ value, idx });
+
+    while (this.minDeque.length && this.minDeque[this.minDeque.length - 1].value >= value) {
+      this.minDeque.pop();
+    }
+    this.minDeque.push({ value, idx });
+
+    if (this.values.length > this.period) {
+      const removed = this.values.shift();
+      this.sum -= removed.value;
+      this.sumSquares -= removed.value * removed.value;
+      if (this.maxDeque[0].idx === removed.idx) this.maxDeque.shift();
+      if (this.minDeque[0].idx === removed.idx) this.minDeque.shift();
+    }
+  }
+
+  isFull() {
+    return this.values.length === this.period;
+  }
+
+  avg() {
+    return this.isFull() ? this.sum / this.period : null;
+  }
+
+  variance() {
+    if (!this.isFull()) return null;
+    const mean = this.sum / this.period;
+    return this.sumSquares / this.period - mean * mean;
+  }
+
+  std() {
+    const v = this.variance();
+    return v != null ? Math.sqrt(Math.max(v, 0)) : null;
+  }
+
+  max() {
+    return this.isFull() ? this.maxDeque[0].value : null;
+  }
+
+  min() {
+    return this.isFull() ? this.minDeque[0].value : null;
+  }
+
+  maxAge() {
+    return this.isFull() ? this.index - 1 - this.maxDeque[0].idx : null;
+  }
+
+  minAge() {
+    return this.isFull() ? this.index - 1 - this.minDeque[0].idx : null;
+  }
+}


### PR DESCRIPTION
## Summary
- add stateful `RollingWindow` utility for running sum/min/max/std
- refactor ATR, Aroon, and Bollinger indicators to use the new helper

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68c1df7d90f08325b757f3551584185a