### PR TITLE
Refactor ATR to use trueRange utility

### DIFF
--- a/docs/crypto-signals-cli-spec.md
+++ b/docs/crypto-signals-cli-spec.md
@@ -286,7 +286,7 @@ Visoms komandoms palaikyk `--dry-run`, `--limit`, `--verbose`.
 │  │  └─ backtest.js
 │  └─ utils/
 │     ├─ time.js
-│     ├─ math.js              # SMA, EMA, STDEV, rolling windows
+│     ├─ math.js              # SMA, EMA, STDEV, TrueRange, rolling windows
 │     └─ logger.js
 ├─ test/                      # Jest
 │  ├─ unit/
@@ -310,9 +310,8 @@ Visoms komandoms palaikyk `--dry-run`, `--limit`, `--verbose`.
 
 - Rolling langai: naudokite efektyvius slenkančius skaičiavimus (ne recalcul nuo nulio)
 - Naudingos utilės:
-  - `SMA(N)`, `EMA(N)`
-  - `STDEV(N)`
-  - `TrueRange`, `ATR`
+  - `SMA(N)`, `EMA(N)`, `STDEV(N)`, `TrueRange(high,low,prevClose)`
+  - `ATR`
   - `AroonUp/Down(highs,lows,N)`
 - Viską maršrutuoti per tranzakcijas arba „upsert“ (`on conflict do update`) – kad būtų idempotentiška
 

--- a/src/core/indicators/atr.js
+++ b/src/core/indicators/atr.js
@@ -1,13 +1,10 @@
-import { RollingWindow } from '../../utils/math.js';
+import { RollingWindow, trueRange } from '../../utils/math.js';
 
 export function atr(highs, lows, closes, period = 14) {
   if (highs.length < period + 1) return null;
   const window = new RollingWindow(period);
   for (let i = 1; i < highs.length; i++) {
-    const hl = highs[i] - lows[i];
-    const hc = Math.abs(highs[i] - closes[i - 1]);
-    const lc = Math.abs(lows[i] - closes[i - 1]);
-    window.push(Math.max(hl, hc, lc));
+    window.push(trueRange(highs[i], lows[i], closes[i - 1]));
   }
   return window.avg();
 }

--- a/src/utils/math.js
+++ b/src/utils/math.js
@@ -14,6 +14,13 @@ export function stdev(values) {
   return Math.sqrt(variance);
 }
 
+export function trueRange(currHigh, currLow, prevClose) {
+  const hl = currHigh - currLow;
+  const hc = Math.abs(currHigh - prevClose);
+  const lc = Math.abs(currLow - prevClose);
+  return Math.max(hl, hc, lc);
+}
+
 export function rolling(values, window, fn) {
   const result = [];
   for (let i = window; i <= values.length; i++) {

--- a/test/unit/math.test.js
+++ b/test/unit/math.test.js
@@ -1,0 +1,7 @@
+import { trueRange } from '../../src/utils/math.js';
+
+test('trueRange scenarios', () => {
+  expect(trueRange(10, 5, 7)).toBe(5);
+  expect(trueRange(11, 8, 5)).toBe(6);
+  expect(trueRange(10, 4, 12)).toBe(8);
+});


### PR DESCRIPTION
## Summary
- implement `trueRange` math helper and export it
- refactor ATR indicator to reuse `trueRange`
- document new utility in spec and add unit tests

## Testing
- `npm test`
- `npm run lint` *(fails: 'getServerTime' is defined but never used, 'fetchJson' is defined but never used, Unexpected constant condition in retry.js)*

------
https://chatgpt.com/codex/tasks/task_e_68c1e15d9aa88325a267d056f2845bbc