### PR TITLE
feat: batch DB operations with transactions

### DIFF
--- a/src/cli/patterns.js
+++ b/src/cli/patterns.js
@@ -15,8 +15,11 @@ export async function detectPatterns({
     [symbol]
   );
 
+  const rows = [];
+
   if (candles.length > 0) {
-    await upsertPatterns(symbol, candles[0].open_time, {
+    rows.push({
+      openTime: candles[0].open_time,
       bullishEngulfing: false,
       bearishEngulfing: false,
       hammer: false,
@@ -27,12 +30,17 @@ export async function detectPatterns({
   for (let i = 1; i < candles.length; i++) {
     const prev = candles[i - 1];
     const curr = candles[i];
-    await upsertPatterns(symbol, curr.open_time, {
+    rows.push({
+      openTime: curr.open_time,
       bullishEngulfing: bullishEngulfing(prev, curr),
       bearishEngulfing: bearishEngulfing(prev, curr),
       hammer: hammer(curr, hammerOptions),
       shootingStar: shootingStar(curr, starOptions),
     });
+  }
+
+  if (rows.length > 0) {
+    await upsertPatterns(symbol, rows);
   }
 
   logger.info('detect patterns');

--- a/src/storage/db.js
+++ b/src/storage/db.js
@@ -13,4 +13,19 @@ export async function query(sql, params) {
   return rows;
 }
 
-export default { query };
+export async function withTransaction(fn) {
+  const client = await pool.connect();
+  try {
+    await client.query('BEGIN');
+    const res = await fn(client);
+    await client.query('COMMIT');
+    return res;
+  } catch (err) {
+    await client.query('ROLLBACK');
+    throw err;
+  } finally {
+    client.release();
+  }
+}
+
+export default { query, withTransaction };

--- a/src/storage/repos/candles.js
+++ b/src/storage/repos/candles.js
@@ -1,13 +1,17 @@
-import { query } from '../db.js';
+import { withTransaction } from '../db.js';
 
 export async function insertCandles(symbol, candles, interval = '1m') {
   const table = `candles_${interval}`;
-  for (const c of candles) {
-    await query(
-      `insert into ${table} (symbol, open_time, open, high, low, close, volume)
-       values ($1,$2,$3,$4,$5,$6,$7)
-       on conflict (symbol, open_time) do update set open=$3, high=$4, low=$5, close=$6, volume=$7`,
-      [symbol, c.openTime, c.open, c.high, c.low, c.close, c.volume]
+  await withTransaction(async (client) => {
+    await Promise.all(
+      candles.map((c) =>
+        client.query(
+          `insert into ${table} (symbol, open_time, open, high, low, close, volume)
+           values ($1,$2,$3,$4,$5,$6,$7)
+           on conflict (symbol, open_time) do update set open=$3, high=$4, low=$5, close=$6, volume=$7`,
+          [symbol, c.openTime, c.open, c.high, c.low, c.close, c.volume]
+        )
+      )
     );
-  }
+  });
 }

--- a/src/storage/repos/indicators.js
+++ b/src/storage/repos/indicators.js
@@ -1,13 +1,17 @@
-import { query } from '../db.js';
+import { withTransaction } from '../db.js';
 
 export async function upsertIndicators(symbol, rows) {
-  for (const r of rows) {
-    await query(
-      `insert into indicators_1m (symbol, open_time, data)
-       values ($1,$2,$3)
-       on conflict (symbol, open_time) do update set data=$3`,
-      [symbol, r.openTime, r.data]
+  await withTransaction(async (client) => {
+    await Promise.all(
+      rows.map((r) =>
+        client.query(
+          `insert into indicators_1m (symbol, open_time, data)
+           values ($1,$2,$3)
+           on conflict (symbol, open_time) do update set data=$3`,
+          [symbol, r.openTime, r.data]
+        )
+      )
     );
-  }
+  });
 }
 

--- a/src/storage/repos/patterns.js
+++ b/src/storage/repos/patterns.js
@@ -1,20 +1,25 @@
-import { query } from '../db.js';
+import { withTransaction } from '../db.js';
 
-export async function upsertPatterns(
-  symbol,
-  openTime,
-  {
-    bullishEngulfing = false,
-    bearishEngulfing = false,
-    hammer = false,
-    shootingStar = false
-  } = {}
-) {
-  await query(
-    `insert into patterns_1m (symbol, open_time, bullish_engulfing, bearish_engulfing, hammer, shooting_star)
-     values ($1,$2,$3,$4,$5,$6)
-     on conflict (symbol, open_time)
-     do update set bullish_engulfing=$3, bearish_engulfing=$4, hammer=$5, shooting_star=$6`,
-    [symbol, openTime, bullishEngulfing, bearishEngulfing, hammer, shootingStar]
-  );
+export async function upsertPatterns(symbol, rows) {
+  await withTransaction(async (client) => {
+    await Promise.all(
+      rows.map((r) =>
+        client.query(
+          `insert into patterns_1m (symbol, open_time, bullish_engulfing, bearish_engulfing, hammer, shooting_star)
+           values ($1,$2,$3,$4,$5,$6)
+           on conflict (symbol, open_time)
+           do update set bullish_engulfing=$3, bearish_engulfing=$4, hammer=$5, shooting_star=$6`,
+          [
+            symbol,
+            r.openTime,
+            r.bullishEngulfing ?? false,
+            r.bearishEngulfing ?? false,
+            r.hammer ?? false,
+            r.shootingStar ?? false,
+          ]
+        )
+      )
+    );
+  });
 }
+

--- a/src/storage/repos/signals.js
+++ b/src/storage/repos/signals.js
@@ -1,14 +1,18 @@
-import { query } from '../db.js';
+import { withTransaction } from '../db.js';
 
 export async function upsertSignals(symbol, signals) {
-  for (const s of signals) {
-    await query(
-      `insert into signals (symbol, open_time, signal)
-       values ($1,$2,$3)
-       on conflict (symbol, open_time) do update set signal = excluded.signal`,
-      [symbol, s.openTime, s.signal]
+  await withTransaction(async (client) => {
+    await Promise.all(
+      signals.map((s) =>
+        client.query(
+          `insert into signals (symbol, open_time, signal)
+           values ($1,$2,$3)
+           on conflict (symbol, open_time) do update set signal = excluded.signal`,
+          [symbol, s.openTime, s.signal]
+        )
+      )
     );
-  }
+  });
 }
 
 export default { upsertSignals };

--- a/test/integration/integration.test.js
+++ b/test/integration/integration.test.js
@@ -1,7 +1,11 @@
 import { jest } from '@jest/globals';
 
+const query = jest.fn(async () => []);
+const withTransaction = jest.fn(async (fn) => fn({ query }));
+
 jest.unstable_mockModule('../../src/storage/db.js', () => ({
-  query: jest.fn(async () => [])
+  query,
+  withTransaction,
 }));
 
 jest.unstable_mockModule('../../src/core/binance.js', () => ({
@@ -10,10 +14,9 @@ jest.unstable_mockModule('../../src/core/binance.js', () => ({
 
 const { fetchKlines } = await import('../../src/core/binance.js');
 const { insertCandles } = await import('../../src/storage/repos/candles.js');
-const db = await import('../../src/storage/db.js');
 
 test('fetch and insert', async () => {
   const data = await fetchKlines({ symbol: 'BTCUSDT', interval: '1m', limit: 1 });
-  await insertCandles('BTCUSDT', '1m', data);
-  expect(db.query).toHaveBeenCalled();
+  await insertCandles('BTCUSDT', data, '1m');
+  expect(query).toHaveBeenCalled();
 });

--- a/test/unit/computeIndicators.test.js
+++ b/test/unit/computeIndicators.test.js
@@ -20,12 +20,15 @@ const candles = highsArr.map((h, i) => ({
 
 const upserts = [];
 
+const query = jest.fn(async (sql, params) => {
+  if (/select/i.test(sql)) return candles;
+  upserts.push({ sql, params });
+  return [];
+});
+const withTransaction = jest.fn(async (fn) => fn({ query }));
 jest.unstable_mockModule('../../src/storage/db.js', () => ({
-  query: jest.fn(async (sql, params) => {
-    if (/select/i.test(sql)) return candles;
-    upserts.push({ sql, params });
-    return [];
-  })
+  query,
+  withTransaction,
 }));
 
 const { computeIndicators } = await import('../../src/cli/compute.js');

--- a/test/unit/detectPatterns.test.js
+++ b/test/unit/detectPatterns.test.js
@@ -28,10 +28,11 @@ test('detectPatterns uses custom multipliers', async () => {
     hammer: { lowerMultiplier: 1.5 },
     star: { upperMultiplier: 1.3 },
   });
+  expect(upsertPatternsMock).toHaveBeenCalledTimes(1);
+  const rows = upsertPatternsMock.mock.calls[0][1];
+  const hammerRow = rows.find((r) => r.openTime === 2);
+  expect(hammerRow).toMatchObject({ hammer: true });
 
-  const hammerCall = upsertPatternsMock.mock.calls.find((c) => c[1] === 2);
-  expect(hammerCall[2]).toMatchObject({ hammer: true });
-
-  const starCall = upsertPatternsMock.mock.calls.find((c) => c[1] === 3);
-  expect(starCall[2]).toMatchObject({ shootingStar: true });
+  const starRow = rows.find((r) => r.openTime === 3);
+  expect(starRow).toMatchObject({ shootingStar: true });
 });

--- a/test/unit/patterns-repo.test.js
+++ b/test/unit/patterns-repo.test.js
@@ -1,11 +1,12 @@
 import { jest } from '@jest/globals';
 
 const query = jest.fn();
-await jest.unstable_mockModule('../../src/storage/db.js', () => ({ query }));
+const withTransaction = jest.fn(async (fn) => fn({ query }));
+await jest.unstable_mockModule('../../src/storage/db.js', () => ({ withTransaction }));
 const { upsertPatterns } = await import('../../src/storage/repos/patterns.js');
 
 test('inserts row with all pattern flags false', async () => {
-  await upsertPatterns('BTC', 1, {});
+  await upsertPatterns('BTC', [{ openTime: 1 }]);
   expect(query).toHaveBeenCalledWith(
     expect.stringContaining('insert into patterns_1m'),
     ['BTC', 1, false, false, false, false]


### PR DESCRIPTION
## Summary
- add `withTransaction` helper to run callbacks inside SQL transactions
- batch insert/upsert operations in candle, indicator, pattern, and signal repos
- update pattern detection to persist rows in one atomic batch

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68c1e42d46c4832591eb3dbd084b62bb