### PR TITLE
Add reusable SOLUSDT candle fixture for tests

### DIFF
--- a/src/cli/fetch.js
+++ b/src/cli/fetch.js
@@ -1,4 +1,4 @@
-import { fetchKlinesRange, fetchServerTime, getServerTime } from '../core/binance.js';
+import { fetchKlinesRange, fetchServerTime } from '../core/binance.js';
 import logger from '../utils/logger.js';
 
 export async function fetchKlines(opts) {

--- a/src/core/binance.js
+++ b/src/core/binance.js
@@ -28,20 +28,6 @@ async function rateLimit() {
   lastCall = getServerTime();
 }
 
-async function fetchJson(url, attempts = 3) {
-  for (let i = 0; i < attempts; i++) {
-    try {
-      const res = await fetch(url);
-      if (res.status === 429) throw new Error('rate limit');
-      if (!res.ok) throw new Error('binance error');
-      return res;
-    } catch (err) {
-      if (i === attempts - 1) throw err;
-      await new Promise(r => setTimeout(r, 500 * 2 ** i));
-    }
-  }
-}
-
 export async function fetchServerTime() {
   await rateLimit();
   const url = new URL('/api/v3/time', BASE);

--- a/src/utils/retry.js
+++ b/src/utils/retry.js
@@ -1,6 +1,6 @@
 export async function retry(fn, { retries = 3, factor = 2, minTimeout = 500 } = {}) {
   let attempt = 0;
-  while (true) {
+  for (;;) {
     try {
       return await fn();
     } catch (err) {

--- a/test/fixtures/SOLUSDT_1m_sample.json
+++ b/test/fixtures/SOLUSDT_1m_sample.json
@@ -1,0 +1,5 @@
+[
+  { "openTime": 1, "open": 100, "high": 110, "low": 90, "close": 100, "volume": 1000 },
+  { "openTime": 2, "open": 100, "high": 120, "low": 99, "close": 110, "volume": 1100 },
+  { "openTime": 3, "open": 110, "high": 160, "low": 100, "close": 150, "volume": 1200 }
+]

--- a/test/helpers/fixtures.js
+++ b/test/helpers/fixtures.js
@@ -1,0 +1,10 @@
+import { readFileSync } from 'fs';
+import path from 'path';
+import { fileURLToPath } from 'url';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+
+export function loadFixture(name) {
+  const filePath = path.join(__dirname, '..', 'fixtures', `${name}.json`);
+  return JSON.parse(readFileSync(filePath, 'utf8'));
+}

--- a/test/integration/backtest.test.js
+++ b/test/integration/backtest.test.js
@@ -1,4 +1,5 @@
 import { jest } from '@jest/globals';
+import { loadFixture } from '../helpers/fixtures.js';
 
 jest.unstable_mockModule('../../src/storage/db.js', () => ({
   query: jest.fn(async () => [])
@@ -12,11 +13,7 @@ jest.unstable_mockModule('../../src/storage/repos/equity.js', () => equityRepo);
 const { backtestRun } = await import('../../src/cli/backtest.js');
 
 test('backtest inserts trade and equity', async () => {
-  const candles = [
-    { openTime: 0, open: 100, high: 110, low: 90, close: 100 },
-    { openTime: 1, open: 100, high: 120, low: 99, close: 110 },
-    { openTime: 2, open: 110, high: 160, low: 100, close: 150 }
-  ];
+  const candles = loadFixture('SOLUSDT_1m_sample');
   const signals = [null, 'buy', null];
   await backtestRun({
     strategy: 'test',

--- a/test/integration/patterns.test.js
+++ b/test/integration/patterns.test.js
@@ -1,10 +1,13 @@
 import { jest } from '@jest/globals';
+import { loadFixture } from '../helpers/fixtures.js';
 
-const candles = [
-  { open_time: 1, open: 10, high: 12, low: 8, close: 8 },
-  { open_time: 2, open: 7, high: 12, low: 6, close: 11 },
-  { open_time: 3, open: 10, high: 11, low: 9, close: 10 },
-];
+const candles = loadFixture('SOLUSDT_1m_sample').map(c => ({
+  open_time: c.openTime,
+  open: c.open,
+  high: c.high,
+  low: c.low,
+  close: c.close,
+}));
 
 const query = jest.fn(async (sql) => {
   if (sql.includes('from candles_1m')) {
@@ -19,7 +22,7 @@ jest.unstable_mockModule('../../src/storage/db.js', () => ({
   withTransaction,
 }));
 
-const db = await import('../../src/storage/db.js');
+await import('../../src/storage/db.js');
 const { detectPatterns } = await import('../../src/cli/patterns.js');
 
 test('detect patterns and write to db', async () => {

--- a/test/integration/strategies.test.js
+++ b/test/integration/strategies.test.js
@@ -1,4 +1,5 @@
 import { jest } from '@jest/globals';
+import { loadFixture } from '../helpers/fixtures.js';
 
 const queryMock = jest.fn();
 const upsertMock = jest.fn();
@@ -56,11 +57,12 @@ describe('signals generation and backtest integration', () => {
       { openTime: 3, signal: 'sell' },
     ]);
 
-    const candles = [
-      { openTime: 1, high: 110, low: 90, close: 100 },
-      { openTime: 2, high: 120, low: 95, close: 110 },
-      { openTime: 3, high: 130, low: 100, close: 120 },
-    ];
+    const candles = loadFixture('SOLUSDT_1m_sample').map(c => ({
+      openTime: c.openTime,
+      high: c.high,
+      low: c.low,
+      close: c.close,
+    }));
 
     const generated = upsertMock.mock.calls[0][1];
     const signals = candles.map(c => {
@@ -117,11 +119,12 @@ describe('signals generation and backtest integration', () => {
       { openTime: 3, signal: 'sell' },
     ]);
 
-    const candles = [
-      { openTime: 1, high: 110, low: 90, close: 100 },
-      { openTime: 2, high: 100, low: 70, close: 80 },
-      { openTime: 3, high: 130, low: 110, close: 120 },
-    ];
+    const candles = loadFixture('SOLUSDT_1m_sample').map(c => ({
+      openTime: c.openTime,
+      high: c.high,
+      low: c.low,
+      close: c.close,
+    }));
 
     const generated = upsertMock.mock.calls[0][1];
     const signals = candles.map(c => {


### PR DESCRIPTION
## Summary
- add SOLUSDT_1m_sample candle fixture and helper loader
- refactor integration tests to use the shared fixture
- clean up unused code and constant loop for lint compliance

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c1e863bb58832589c6c1c716c4945d