### PR TITLE
Add paper trading module with tests

### DIFF
--- a/src/cli/paper.js
+++ b/src/cli/paper.js
@@ -1,0 +1,20 @@
+import { runBacktest } from '../core/backtest/runner.js';
+import { insertTradesPaper } from '../storage/repos/tradesPaper.js';
+import { insertEquityPaper } from '../storage/repos/equityPaper.js';
+import logger from '../utils/logger.js';
+
+export async function paperRun(opts) {
+  const { strategy, symbol, initial, candles, signals, ...rest } = opts;
+  const { trades, equity } = await runBacktest({
+    candles,
+    signals,
+    initialBalance: Number(initial),
+    ...rest
+  });
+  await insertTradesPaper(symbol, trades);
+  await insertEquityPaper(symbol, equity);
+  logger.info(`paper trading completed for ${symbol} using ${strategy}`);
+  return { trades, equity };
+}
+
+export default { paperRun };

--- a/src/storage/repos/equityPaper.js
+++ b/src/storage/repos/equityPaper.js
@@ -1,0 +1,13 @@
+import { query } from '../db.js';
+
+export async function insertEquityPaper(symbol, equity) {
+  for (const e of equity) {
+    await query(
+      `insert into equity_paper (ts, equity)
+       values ($1,$2)`,
+      [e.time, e.balance]
+    );
+  }
+}
+
+export default { insertEquityPaper };

--- a/src/storage/repos/tradesPaper.js
+++ b/src/storage/repos/tradesPaper.js
@@ -1,0 +1,13 @@
+import { query } from '../db.js';
+
+export async function insertTradesPaper(symbol, trades) {
+  for (const t of trades) {
+    await query(
+      `insert into trades_paper (symbol, open_time, qty, price)
+       values ($1,$2,$3,$4)`,
+      [symbol, t.entryTime, 1, t.entryPrice]
+    );
+  }
+}
+
+export default { insertTradesPaper };

--- a/test/integration/paper-cli.test.js
+++ b/test/integration/paper-cli.test.js
@@ -1,0 +1,23 @@
+import { jest } from '@jest/globals';
+import { loadFixture } from '../helpers/fixtures.js';
+
+const query = jest.fn(async () => []);
+jest.unstable_mockModule('../../src/storage/db.js', () => ({ query }));
+
+const { paperRun } = await import('../../src/cli/paper.js');
+
+test('paper CLI writes to trades_paper and equity_paper', async () => {
+  const candles = loadFixture('SOLUSDT_1m_sample');
+  const signals = [null, 'buy', 'sell'];
+  await paperRun({
+    strategy: 'test',
+    symbol: 'SOLUSDT',
+    initial: 1000,
+    candles,
+    signals,
+    atrPeriod: 1
+  });
+  const statements = query.mock.calls.map(c => c[0]);
+  expect(statements.some(s => s.includes('insert into trades_paper'))).toBe(true);
+  expect(statements.some(s => s.includes('insert into equity_paper'))).toBe(true);
+});

--- a/test/unit/paperRun.test.js
+++ b/test/unit/paperRun.test.js
@@ -1,0 +1,29 @@
+import { jest } from '@jest/globals';
+import { loadFixture } from '../helpers/fixtures.js';
+
+const tradesRepo = { insertTradesPaper: jest.fn(async () => {}) };
+const equityRepo = { insertEquityPaper: jest.fn(async () => {}) };
+
+jest.unstable_mockModule('../../src/storage/repos/tradesPaper.js', () => tradesRepo);
+jest.unstable_mockModule('../../src/storage/repos/equityPaper.js', () => equityRepo);
+
+const { paperRun } = await import('../../src/cli/paper.js');
+
+test('paperRun executes trade, records equity, and calculates pnl', async () => {
+  const candles = loadFixture('SOLUSDT_1m_sample');
+  const signals = [null, 'buy', 'sell'];
+  await paperRun({
+    strategy: 'test',
+    symbol: 'SOLUSDT',
+    initial: 1000,
+    candles,
+    signals,
+    atrPeriod: 1
+  });
+  expect(tradesRepo.insertTradesPaper).toHaveBeenCalled();
+  expect(equityRepo.insertEquityPaper).toHaveBeenCalled();
+  const trades = tradesRepo.insertTradesPaper.mock.calls[0][1];
+  expect(trades[0].pnl).toBe(42);
+  const equity = equityRepo.insertEquityPaper.mock.calls[0][1];
+  expect(equity[equity.length - 1].balance).toBe(1042);
+});


### PR DESCRIPTION
## Summary
- implement paper trading CLI writing to `trades_paper` and `equity_paper`
- store paper trades and equity snapshots in new repositories
- cover paper trading with unit and integration tests

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68c1ec68d37883259c17956125b0ef24