### PR TITLE
Add tests for storage repositories

### DIFF
--- a/test/unit/candles-repo.test.js
+++ b/test/unit/candles-repo.test.js
@@ -1,0 +1,16 @@
+import { jest } from '@jest/globals';
+
+const query = jest.fn();
+const withTransaction = jest.fn(async (fn) => fn({ query }));
+await jest.unstable_mockModule('../../src/storage/db.js', () => ({ withTransaction }));
+const { insertCandles } = await import('../../src/storage/repos/candles.js');
+
+test('uses correct table and upsert logic for candles', async () => {
+  await insertCandles('BTC', [{ openTime: 1, open: 2, high: 3, low: 1, close: 2, volume: 10 }], '5m');
+  expect(query).toHaveBeenCalledWith(
+    expect.stringContaining('insert into candles_5m'),
+    ['BTC', 1, 2, 3, 1, 2, 10]
+  );
+  const sql = query.mock.calls[0][0];
+  expect(sql).toMatch(/on conflict \(symbol, open_time\) do update/);
+});

--- a/test/unit/equity-repo.test.js
+++ b/test/unit/equity-repo.test.js
@@ -1,0 +1,13 @@
+import { jest } from '@jest/globals';
+
+const query = jest.fn();
+await jest.unstable_mockModule('../../src/storage/db.js', () => ({ query }));
+const { insertEquity } = await import('../../src/storage/repos/equity.js');
+
+test('inserts equity records', async () => {
+  await insertEquity('BTC', [{ time: 1, balance: 100 }]);
+  expect(query).toHaveBeenCalledWith(
+    expect.stringContaining('insert into equity'),
+    ['BTC', 1, 100]
+  );
+});

--- a/test/unit/equityPaper-repo.test.js
+++ b/test/unit/equityPaper-repo.test.js
@@ -1,0 +1,13 @@
+import { jest } from '@jest/globals';
+
+const query = jest.fn();
+await jest.unstable_mockModule('../../src/storage/db.js', () => ({ query }));
+const { insertEquityPaper } = await import('../../src/storage/repos/equityPaper.js');
+
+test('inserts paper equity records', async () => {
+  await insertEquityPaper('BTC', [{ time: 1, balance: 100 }]);
+  expect(query).toHaveBeenCalledWith(
+    expect.stringContaining('insert into equity_paper'),
+    [1, 100]
+  );
+});

--- a/test/unit/indicators-repo.test.js
+++ b/test/unit/indicators-repo.test.js
@@ -1,0 +1,17 @@
+import { jest } from '@jest/globals';
+
+const query = jest.fn();
+const withTransaction = jest.fn(async (fn) => fn({ query }));
+await jest.unstable_mockModule('../../src/storage/db.js', () => ({ withTransaction }));
+const { upsertIndicators } = await import('../../src/storage/repos/indicators.js');
+
+test('upserts indicators with conflict handling', async () => {
+  const data = { rsi: 30 };
+  await upsertIndicators('BTC', [{ openTime: 1, data }]);
+  expect(query).toHaveBeenCalledWith(
+    expect.stringContaining('insert into indicators_1m'),
+    ['BTC', 1, data]
+  );
+  const sql = query.mock.calls[0][0];
+  expect(sql).toMatch(/on conflict \(symbol, open_time\) do update set data=\$3/);
+});

--- a/test/unit/jobs-repo.test.js
+++ b/test/unit/jobs-repo.test.js
@@ -1,0 +1,43 @@
+import { jest } from '@jest/globals';
+
+const query = jest.fn();
+await jest.unstable_mockModule('../../src/storage/db.js', () => ({ query }));
+const { getJobRunAt, setJobRunAt } = await import('../../src/storage/repos/jobs.js');
+
+beforeEach(() => {
+  query.mockReset();
+});
+
+test('getJobRunAt returns run time as number', async () => {
+  query.mockResolvedValueOnce([{ run_at: '123' }]);
+  const result = await getJobRunAt('job1');
+  expect(query).toHaveBeenCalledWith('select run_at from jobs where name=$1', ['job1']);
+  expect(result).toBe(123);
+});
+
+test('getJobRunAt returns null when missing', async () => {
+  query.mockResolvedValueOnce([]);
+  const result = await getJobRunAt('job2');
+  expect(query).toHaveBeenCalledWith('select run_at from jobs where name=$1', ['job2']);
+  expect(result).toBeNull();
+});
+
+test('setJobRunAt updates existing job', async () => {
+  query.mockResolvedValueOnce([{ id: 1 }]);
+  await setJobRunAt('job1', 1000);
+  expect(query).toHaveBeenCalledWith(
+    'update jobs set run_at=$2 where name=$1 returning id',
+    ['job1', 1000]
+  );
+  expect(query).toHaveBeenCalledTimes(1);
+});
+
+test('setJobRunAt inserts when job missing', async () => {
+  query.mockResolvedValueOnce([]);
+  query.mockResolvedValueOnce([]);
+  await setJobRunAt('job1', 2000);
+  expect(query.mock.calls).toEqual([
+    ['update jobs set run_at=$2 where name=$1 returning id', ['job1', 2000]],
+    ['insert into jobs (name, run_at) values ($1,$2)', ['job1', 2000]],
+  ]);
+});

--- a/test/unit/patterns-repo.test.js
+++ b/test/unit/patterns-repo.test.js
@@ -11,4 +11,6 @@ test('inserts row with all pattern flags false', async () => {
     expect.stringContaining('insert into patterns_1m'),
     ['BTC', 1, false, false, false, false]
   );
+  const sql = query.mock.calls[0][0];
+  expect(sql).toMatch(/on conflict \(symbol, open_time\)/);
 });

--- a/test/unit/signals-repo.test.js
+++ b/test/unit/signals-repo.test.js
@@ -1,0 +1,16 @@
+import { jest } from '@jest/globals';
+
+const query = jest.fn();
+const withTransaction = jest.fn(async (fn) => fn({ query }));
+await jest.unstable_mockModule('../../src/storage/db.js', () => ({ withTransaction }));
+const { upsertSignals } = await import('../../src/storage/repos/signals.js');
+
+test('upserts signals with conflict handling', async () => {
+  await upsertSignals('BTC', [{ openTime: 1, signal: 'BUY' }]);
+  expect(query).toHaveBeenCalledWith(
+    expect.stringContaining('insert into signals'),
+    ['BTC', 1, 'BUY']
+  );
+  const sql = query.mock.calls[0][0];
+  expect(sql).toMatch(/on conflict \(symbol, open_time\) do update set signal = excluded.signal/);
+});

--- a/test/unit/trades-repo.test.js
+++ b/test/unit/trades-repo.test.js
@@ -1,0 +1,13 @@
+import { jest } from '@jest/globals';
+
+const query = jest.fn();
+await jest.unstable_mockModule('../../src/storage/db.js', () => ({ query }));
+const { insertTrades } = await import('../../src/storage/repos/trades.js');
+
+test('inserts trades records', async () => {
+  await insertTrades('BTC', [{ entryTime: 1, exitTime: 2, entryPrice: 10, exitPrice: 12, side: 'LONG', pnl: 2 }]);
+  expect(query).toHaveBeenCalledWith(
+    expect.stringContaining('insert into trades'),
+    ['BTC', 1, 2, 10, 12, 'LONG', 2]
+  );
+});

--- a/test/unit/tradesPaper-repo.test.js
+++ b/test/unit/tradesPaper-repo.test.js
@@ -1,0 +1,13 @@
+import { jest } from '@jest/globals';
+
+const query = jest.fn();
+await jest.unstable_mockModule('../../src/storage/db.js', () => ({ query }));
+const { insertTradesPaper } = await import('../../src/storage/repos/tradesPaper.js');
+
+test('inserts paper trades records', async () => {
+  await insertTradesPaper('BTC', [{ entryTime: 1, entryPrice: 10 }]);
+  expect(query).toHaveBeenCalledWith(
+    expect.stringContaining('insert into trades_paper'),
+    ['BTC', 1, 1, 10]
+  );
+});


### PR DESCRIPTION
## Summary
- add unit tests for storage repos capturing SQL queries
- cover upsert and conflict behavior for candles, indicators, signals
- verify jobs repository update/insert paths and basic inserts for equity and trades

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68c1f212e6148325be9d9a90b056f9af