### PR TITLE
Query database for CLI backtest and add integration test

### DIFF
--- a/src/cli/backtest.js
+++ b/src/cli/backtest.js
@@ -1,16 +1,53 @@
 import { runBacktest } from '../core/backtest/runner.js';
+import { query } from '../storage/db.js';
 import { insertTradesPaper } from '../storage/repos/tradesPaper.js';
 import { insertEquityPaper } from '../storage/repos/equityPaper.js';
 import logger from '../utils/logger.js';
 
 export async function backtestRun(opts) {
-  const { strategy, symbol, initial, candles, signals, ...rest } = opts;
+  const {
+    strategy,
+    symbol,
+    from,
+    to,
+    interval = '1m',
+    initial,
+    candles: candlesInput,
+    signals: signalsInput,
+    ...rest
+  } = opts;
+
+  let candles = candlesInput;
+  if (!candles) {
+    const rows = await query(
+      `select open_time, open, high, low, close from candles_${interval} where symbol=$1 and open_time >= $2 and open_time <= $3 order by open_time`,
+      [symbol, from, to]
+    );
+    candles = rows.map((c) => ({
+      openTime: Number(c.open_time),
+      high: Number(c.high),
+      low: Number(c.low),
+      close: Number(c.close)
+    }));
+  }
+
+  let signals = signalsInput;
+  if (!signals) {
+    const rows = await query(
+      `select open_time, signal from signals where symbol=$1 and strategy=$2 and open_time >= $3 and open_time <= $4 order by open_time`,
+      [symbol, strategy, from, to]
+    );
+    const map = new Map(rows.map((r) => [Number(r.open_time), r.signal]));
+    signals = candles.map((c) => map.get(c.openTime) || null);
+  }
+
   const { trades, equity } = await runBacktest({
     candles,
     signals,
     initialBalance: Number(initial),
     ...rest
   });
+
   await insertTradesPaper(symbol, trades);
   await insertEquityPaper(symbol, equity);
   logger.info(`backtest completed for ${symbol} using ${strategy}`);

--- a/test/integration/backtest-cli.test.js
+++ b/test/integration/backtest-cli.test.js
@@ -1,0 +1,47 @@
+import { jest } from '@jest/globals';
+import { loadFixture } from '../helpers/fixtures.js';
+
+const queryMock = jest.fn();
+await jest.unstable_mockModule('../../src/storage/db.js', () => ({
+  query: queryMock,
+}));
+
+const tradesRepo = { insertTradesPaper: jest.fn(async () => {}) };
+const equityRepo = { insertEquityPaper: jest.fn(async () => {}) };
+await jest.unstable_mockModule('../../src/storage/repos/tradesPaper.js', () => tradesRepo);
+await jest.unstable_mockModule('../../src/storage/repos/equityPaper.js', () => equityRepo);
+
+const { backtestRun } = await import('../../src/cli/backtest.js');
+
+test('backtest runs using DB data', async () => {
+  const candles = loadFixture('SOLUSDT_1m_sample');
+  queryMock
+    .mockResolvedValueOnce(
+      candles.map(c => ({
+        open_time: c.openTime,
+        open: c.open,
+        high: c.high,
+        low: c.low,
+        close: c.close,
+      }))
+    )
+    .mockResolvedValueOnce([{ open_time: 2, signal: 'buy' }]);
+
+  await backtestRun({
+    strategy: 'test',
+    symbol: 'BTCUSDT',
+    from: 1,
+    to: 3,
+    interval: '1m',
+    initial: 1000,
+    atrPeriod: 1,
+  });
+
+  expect(queryMock).toHaveBeenCalledTimes(2);
+  expect(queryMock.mock.calls[0][0]).toMatch(/candles_1m/);
+  expect(queryMock.mock.calls[1][0]).toMatch(/signals/);
+  expect(tradesRepo.insertTradesPaper).toHaveBeenCalled();
+  expect(equityRepo.insertEquityPaper).toHaveBeenCalled();
+  expect(tradesRepo.insertTradesPaper.mock.calls[0][1].length).toBeGreaterThan(0);
+  expect(equityRepo.insertEquityPaper.mock.calls[0][1].length).toBeGreaterThan(0);
+});


### PR DESCRIPTION
## Summary
- Query candles and signals tables using symbol, interval, date range and strategy
- Map fetched data into runBacktest and store resulting trades and equity
- Add integration test verifying backtest works with only CLI parameters

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c1f5be0468832582c927b9a935d9fd