### PR TITLE
Record additional paper trade and equity fields

### DIFF
--- a/migrations/1700000000000_init.js
+++ b/migrations/1700000000000_init.js
@@ -101,13 +101,20 @@ export async function up(pgm) {
     id: 'id',
     symbol: { type: 'text', notNull: true },
     open_time: { type: 'bigint', notNull: true },
+    ts_close: { type: 'bigint' },
+    side: { type: 'text' },
     qty: 'numeric',
-    price: 'numeric'
+    price: 'numeric',
+    exit: 'numeric',
+    pnl: 'numeric',
+    status: 'text'
   });
 
   pgm.createTable('equity_paper', {
     ts: { type: 'bigint', primaryKey: true },
-    equity: 'numeric'
+    equity: 'numeric',
+    source: 'text',
+    symbol: 'text'
   });
 
   pgm.createTable('jobs', {

--- a/migrations/db.structure.sql
+++ b/migrations/db.structure.sql
@@ -121,8 +121,13 @@ create table if not exists trades_paper
         primary key,
     symbol    text   not null,
     open_time bigint not null,
+    ts_close  bigint,
+    side      text,
     qty       numeric,
-    price     numeric
+    price     numeric,
+    exit      numeric,
+    pnl       numeric,
+    status    text
 );
 
 alter table trades_paper
@@ -132,7 +137,9 @@ create table if not exists equity_paper
 (
     ts     bigint not null
         primary key,
-    equity numeric
+    equity numeric,
+    source text,
+    symbol text
 );
 
 alter table equity_paper

--- a/src/cli/backtest.js
+++ b/src/cli/backtest.js
@@ -47,9 +47,10 @@ export async function backtestRun(opts) {
     initialBalance: Number(initial),
     ...rest
   });
+  const tradesWithStatus = trades.map(t => ({ ...t, status: t.status || 'closed' }));
 
-  await insertTradesPaper(symbol, trades);
-  await insertEquityPaper(symbol, equity);
+  await insertTradesPaper(symbol, tradesWithStatus);
+  await insertEquityPaper('backtest', symbol, equity);
   logger.info(`backtest completed for ${symbol} using ${strategy}`);
   return { trades, equity };
 }

--- a/src/cli/paper.js
+++ b/src/cli/paper.js
@@ -11,8 +11,9 @@ export async function paperRun(opts) {
     initialBalance: Number(initial),
     ...rest
   });
-  await insertTradesPaper(symbol, trades);
-  await insertEquityPaper(symbol, equity);
+  const tradesWithStatus = trades.map(t => ({ ...t, status: t.status || 'closed' }));
+  await insertTradesPaper(symbol, tradesWithStatus);
+  await insertEquityPaper('paper', symbol, equity);
   logger.info(`paper trading completed for ${symbol} using ${strategy}`);
   return { trades, equity };
 }

--- a/src/storage/repos/equityPaper.js
+++ b/src/storage/repos/equityPaper.js
@@ -1,11 +1,11 @@
 import { query } from '../db.js';
 
-export async function insertEquityPaper(symbol, equity) {
+export async function insertEquityPaper(source, symbol, equity) {
   for (const e of equity) {
     await query(
-      `insert into equity_paper (ts, equity)
-       values ($1,$2)`,
-      [e.time, e.balance]
+      `insert into equity_paper (ts, equity, source, symbol)
+       values ($1,$2,$3,$4)`,
+      [e.time, e.balance, source, symbol]
     );
   }
 }

--- a/src/storage/repos/tradesPaper.js
+++ b/src/storage/repos/tradesPaper.js
@@ -3,9 +3,19 @@ import { query } from '../db.js';
 export async function insertTradesPaper(symbol, trades) {
   for (const t of trades) {
     await query(
-      `insert into trades_paper (symbol, open_time, qty, price)
-       values ($1,$2,$3,$4)`,
-      [symbol, t.entryTime, 1, t.entryPrice]
+      `insert into trades_paper (symbol, open_time, ts_close, side, qty, price, exit, pnl, status)
+       values ($1,$2,$3,$4,$5,$6,$7,$8,$9)`,
+      [
+        symbol,
+        t.entryTime,
+        t.exitTime,
+        t.side,
+        1,
+        t.entryPrice,
+        t.exitPrice,
+        t.pnl,
+        t.status
+      ]
     );
   }
 }

--- a/test/integration/backtest-cli.test.js
+++ b/test/integration/backtest-cli.test.js
@@ -43,5 +43,5 @@ test('backtest runs using DB data', async () => {
   expect(tradesRepo.insertTradesPaper).toHaveBeenCalled();
   expect(equityRepo.insertEquityPaper).toHaveBeenCalled();
   expect(tradesRepo.insertTradesPaper.mock.calls[0][1].length).toBeGreaterThan(0);
-  expect(equityRepo.insertEquityPaper.mock.calls[0][1].length).toBeGreaterThan(0);
+  expect(equityRepo.insertEquityPaper.mock.calls[0][2].length).toBeGreaterThan(0);
 });

--- a/test/integration/backtest.test.js
+++ b/test/integration/backtest.test.js
@@ -28,5 +28,5 @@ test('backtest inserts trade and equity', async () => {
   expect(tradesRepo.insertTradesPaper).toHaveBeenCalled();
   expect(equityRepo.insertEquityPaper).toHaveBeenCalled();
   expect(tradesRepo.insertTradesPaper.mock.calls[0][1].length).toBeGreaterThan(0);
-  expect(equityRepo.insertEquityPaper.mock.calls[0][1].length).toBeGreaterThan(0);
+  expect(equityRepo.insertEquityPaper.mock.calls[0][2].length).toBeGreaterThan(0);
 });

--- a/test/unit/equityPaper-repo.test.js
+++ b/test/unit/equityPaper-repo.test.js
@@ -5,9 +5,9 @@ await jest.unstable_mockModule('../../src/storage/db.js', () => ({ query }));
 const { insertEquityPaper } = await import('../../src/storage/repos/equityPaper.js');
 
 test('inserts paper equity records', async () => {
-  await insertEquityPaper('BTC', [{ time: 1, balance: 100 }]);
+  await insertEquityPaper('paper', 'BTC', [{ time: 1, balance: 100 }]);
   expect(query).toHaveBeenCalledWith(
     expect.stringContaining('insert into equity_paper'),
-    [1, 100]
+    [1, 100, 'paper', 'BTC']
   );
 });

--- a/test/unit/paperRun.test.js
+++ b/test/unit/paperRun.test.js
@@ -23,7 +23,9 @@ test('paperRun executes trade, records equity, and calculates pnl', async () => 
   expect(tradesRepo.insertTradesPaper).toHaveBeenCalled();
   expect(equityRepo.insertEquityPaper).toHaveBeenCalled();
   const trades = tradesRepo.insertTradesPaper.mock.calls[0][1];
-  expect(trades[0].pnl).toBe(42);
-  const equity = equityRepo.insertEquityPaper.mock.calls[0][1];
+  expect(trades[0]).toMatchObject({ pnl: 42, status: 'closed' });
+  const equity = equityRepo.insertEquityPaper.mock.calls[0][2];
   expect(equity[equity.length - 1].balance).toBe(1042);
+  expect(equityRepo.insertEquityPaper.mock.calls[0][0]).toBe('paper');
+  expect(equityRepo.insertEquityPaper.mock.calls[0][1]).toBe('SOLUSDT');
 });

--- a/test/unit/tradesPaper-repo.test.js
+++ b/test/unit/tradesPaper-repo.test.js
@@ -5,9 +5,19 @@ await jest.unstable_mockModule('../../src/storage/db.js', () => ({ query }));
 const { insertTradesPaper } = await import('../../src/storage/repos/tradesPaper.js');
 
 test('inserts paper trades records', async () => {
-  await insertTradesPaper('BTC', [{ entryTime: 1, entryPrice: 10 }]);
+  await insertTradesPaper('BTC', [
+    {
+      entryTime: 1,
+      exitTime: 2,
+      side: 'long',
+      entryPrice: 10,
+      exitPrice: 12,
+      pnl: 2,
+      status: 'closed'
+    }
+  ]);
   expect(query).toHaveBeenCalledWith(
     expect.stringContaining('insert into trades_paper'),
-    ['BTC', 1, 1, 10]
+    ['BTC', 1, 2, 'long', 1, 10, 12, 2, 'closed']
   );
 });


### PR DESCRIPTION
## Summary
- Store trade close time, side, exit price, PnL and status in `trades_paper`
- Allow paper equity records to include source and symbol
- Propagate new metadata through paper and backtest runs
- Expand DB schema and tests for the new fields

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c1fdc61d7c832599eb6a3afe798196