### PR TITLE
Add CLI command for manual equity snapshots

### DIFF
--- a/bin/cs
+++ b/bin/cs
@@ -6,6 +6,7 @@ import { computeIndicators } from '../src/cli/compute.js';
 import { detectPatterns } from '../src/cli/patterns.js';
 import { signalsGenerate } from '../src/cli/signals.js';
 import { backtestRun } from '../src/cli/backtest.js';
+import { paperEquitySnapshot } from '../src/cli/paper.js';
 
 const program = new Command();
 program
@@ -40,5 +41,11 @@ program
   .requiredOption('--interval <interval>')
   .requiredOption('--strategy <strategy>')
   .action(signalsGenerate);
+
+program
+  .command('paper:equity:snapshot')
+  .requiredOption('--equity <equity>')
+  .requiredOption('--source <source>')
+  .action(paperEquitySnapshot);
 
 program.parseAsync(process.argv);

--- a/src/cli/paper.js
+++ b/src/cli/paper.js
@@ -18,4 +18,11 @@ export async function paperRun(opts) {
   return { trades, equity };
 }
 
-export default { paperRun };
+export async function paperEquitySnapshot(opts) {
+  const { equity, source } = opts;
+  const ts = Date.now();
+  await insertEquityPaper(source, null, [{ time: ts, balance: Number(equity) }]);
+  logger.info(`equity snapshot recorded for ${source}`);
+}
+
+export default { paperRun, paperEquitySnapshot };

--- a/test/integration/paper-equity-snapshot.test.js
+++ b/test/integration/paper-equity-snapshot.test.js
@@ -1,0 +1,12 @@
+import { jest } from '@jest/globals';
+
+const query = jest.fn(async () => []);
+jest.unstable_mockModule('../../src/storage/db.js', () => ({ query }));
+
+const { paperEquitySnapshot } = await import('../../src/cli/paper.js');
+
+test('paper equity snapshot CLI writes to equity_paper', async () => {
+  await paperEquitySnapshot({ equity: 10150, source: 'live' });
+  const statements = query.mock.calls.map(c => c[0]);
+  expect(statements.some(s => s.includes('insert into equity_paper'))).toBe(true);
+});


### PR DESCRIPTION
## Summary
- add `paperEquitySnapshot` helper to store single equity entries with current timestamp
- wire `paper:equity:snapshot` CLI command requiring `--equity` and `--source`
- test that equity snapshot command writes to `equity_paper`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68c1ff90bb048325a2a1f6f1c005e181