### PR TITLE
feat: add backtest metrics and export results

### DIFF
--- a/src/cli/backtest.js
+++ b/src/cli/backtest.js
@@ -3,6 +3,8 @@ import { query } from '../storage/db.js';
 import { insertTradesPaper } from '../storage/repos/tradesPaper.js';
 import { insertEquityPaper } from '../storage/repos/equityPaper.js';
 import logger from '../utils/logger.js';
+import fs from 'fs/promises';
+import path from 'path';
 
 export async function backtestRun(opts) {
   const {
@@ -41,7 +43,7 @@ export async function backtestRun(opts) {
     signals = candles.map((c) => map.get(c.openTime) || null);
   }
 
-  const { trades, equity } = await runBacktest({
+  const { trades, equity, metrics } = await runBacktest({
     candles,
     signals,
     initialBalance: Number(initial),
@@ -51,6 +53,46 @@ export async function backtestRun(opts) {
 
   await insertTradesPaper(symbol, tradesWithStatus);
   await insertEquityPaper('backtest', symbol, equity);
+
+  const dirName = `${strategy}_${symbol}_${interval}_${from}_${to}`;
+  const outDir = path.join('out', 'backtest', dirName);
+  await fs.mkdir(outDir, { recursive: true });
+
+  const tradesHeader = 'entryTime,exitTime,entryPrice,exitPrice,side,pnl\n';
+  const tradesCsv =
+    tradesHeader +
+    trades
+      .map(
+        t =>
+          `${t.entryTime},${t.exitTime},${t.entryPrice},${t.exitPrice},${t.side},${t.pnl}`
+      )
+      .join('\n');
+  await fs.writeFile(path.join(outDir, 'trades.csv'), tradesCsv);
+
+  const equityHeader = 'time,balance\n';
+  const equityCsv =
+    equityHeader + equity.map(e => `${e.time},${e.balance}`).join('\n');
+  await fs.writeFile(path.join(outDir, 'equity.csv'), equityCsv);
+
+  await fs.writeFile(
+    path.join(outDir, 'metrics.json'),
+    JSON.stringify(metrics, null, 2)
+  );
+
+  const config = {
+    strategy,
+    symbol,
+    from,
+    to,
+    interval,
+    initial,
+    ...rest
+  };
+  await fs.writeFile(
+    path.join(outDir, 'config.json'),
+    JSON.stringify(config, null, 2)
+  );
+
   logger.info(`backtest completed for ${symbol} using ${strategy}`);
-  return { trades, equity };
+  return { trades, equity, metrics };
 }

--- a/test/integration/backtest-output.test.js
+++ b/test/integration/backtest-output.test.js
@@ -1,0 +1,51 @@
+import { jest } from '@jest/globals';
+import fs from 'fs/promises';
+import path from 'path';
+
+jest.unstable_mockModule('../../src/storage/db.js', () => ({
+  query: jest.fn(async () => [])
+}));
+
+const tradesRepo = { insertTradesPaper: jest.fn(async () => {}) };
+const equityRepo = { insertEquityPaper: jest.fn(async () => {}) };
+jest.unstable_mockModule('../../src/storage/repos/tradesPaper.js', () => tradesRepo);
+jest.unstable_mockModule('../../src/storage/repos/equityPaper.js', () => equityRepo);
+
+const { backtestRun } = await import('../../src/cli/backtest.js');
+
+test('backtest generates metrics and files', async () => {
+  const candles = [
+    { openTime: 1, high: 110, low: 90, close: 100 },
+    { openTime: 2, high: 120, low: 99, close: 110 },
+    { openTime: 3, high: 115, low: 85, close: 90 },
+    { openTime: 4, high: 150, low: 100, close: 140 },
+    { openTime: 5, high: 210, low: 130, close: 205 },
+  ];
+  const signals = [null, 'buy', null, 'buy', null];
+  const { metrics } = await backtestRun({
+    strategy: 'test',
+    symbol: 'BTCUSDT',
+    from: 1,
+    to: 5,
+    interval: '1m',
+    initial: 1000,
+    candles,
+    signals,
+    atrPeriod: 1,
+    atrMultiplier: 1,
+  });
+
+  expect(metrics.winrate).toBeCloseTo(0.5);
+  expect(metrics.profitFactor).toBeCloseTo(60 / 21);
+  expect(metrics.maxDrawdown).toBeCloseTo(21);
+  expect(metrics.avgPnL).toBeCloseTo(19.5);
+
+  const dirName = 'test_BTCUSDT_1m_1_5';
+  const outDir = path.join('out', 'backtest', dirName);
+  const files = ['trades.csv', 'equity.csv', 'metrics.json', 'config.json'];
+  for (const f of files) {
+    await expect(fs.access(path.join(outDir, f))).resolves.toBeUndefined();
+  }
+
+  await fs.rm(path.join('out', 'backtest'), { recursive: true, force: true });
+});


### PR DESCRIPTION
## Summary
- compute win rate, profit factor, drawdown, and average PnL in the backtest runner
- export trades/equity/metrics/config files from backtest CLI
- test that backtest produces metrics and required output files

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c20101fee08325bc29b3656d7c6840