### PR TITLE
feat: add db seed command

### DIFF
--- a/bin/cs
+++ b/bin/cs
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
 import { Command } from 'commander';
-import { dbInit, dbMigrate } from '../src/cli/db.js';
+import { dbInit, dbMigrate, dbSeed } from '../src/cli/db.js';
 import { fetchKlines } from '../src/cli/fetch.js';
 import { computeIndicators } from '../src/cli/compute.js';
 import { detectPatterns } from '../src/cli/patterns.js';
@@ -15,6 +15,7 @@ program
 
 program.command('db:init').action(dbInit);
 program.command('db:migrate').action(dbMigrate);
+program.command('db:seed').action(dbSeed);
 program
   .command('fetch:klines')
   .requiredOption('--symbol <symbol>')

--- a/package.json
+++ b/package.json
@@ -9,7 +9,8 @@
     "start": "node bin/cs",
     "test": "NODE_OPTIONS=--experimental-vm-modules jest --coverage",
     "lint": "eslint .",
-    "migrate": "node-pg-migrate up"
+    "migrate": "node-pg-migrate up",
+    "seed": "node ./scripts/seed-symbols.js"
   },
   "dependencies": {
     "pg": "^8.11.0",

--- a/scripts/seed-symbols.js
+++ b/scripts/seed-symbols.js
@@ -1,0 +1,19 @@
+import { Client } from 'pg';
+import logger from '../src/utils/logger.js';
+
+const symbols = ['BTCUSDT', 'SOLUSDT'];
+
+const client = new Client();
+await client.connect();
+try {
+  for (const symbol of symbols) {
+    await client.query(
+      'INSERT INTO symbols(symbol) VALUES ($1) ON CONFLICT (symbol) DO NOTHING',
+      [symbol]
+    );
+  }
+  logger.info(`seeded ${symbols.length} symbols`);
+} finally {
+  await client.end();
+}
+

--- a/src/cli/db.js
+++ b/src/cli/db.js
@@ -25,3 +25,12 @@ export async function dbMigrate() {
     proc.on('close', code => (code === 0 ? resolve() : reject(new Error('migrate failed'))));
   });
 }
+
+export async function dbSeed() {
+  await new Promise((resolve, reject) => {
+    const __dirname = path.dirname(fileURLToPath(import.meta.url));
+    const script = path.resolve(__dirname, '../../scripts/seed-symbols.js');
+    const proc = spawn('node', [script], { stdio: 'inherit' });
+    proc.on('close', code => (code === 0 ? resolve() : reject(new Error('seed failed'))));
+  });
+}


### PR DESCRIPTION
## Summary
- add db:seed CLI command
- implement dbSeed to run seeding script
- seed default symbols into database

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c2056fcbfc8325a29406ecbd3fd089