### PR TITLE
feat: add candle resampling CLI

### DIFF
--- a/bin/cs
+++ b/bin/cs
@@ -7,6 +7,7 @@ import { detectPatterns } from '../src/cli/patterns.js';
 import { signalsGenerate } from '../src/cli/signals.js';
 import { backtestRun } from '../src/cli/backtest.js';
 import { paperEquitySnapshot } from '../src/cli/paper.js';
+import { resampleCandles } from '../src/cli/resample.js';
 
 const program = new Command();
 program
@@ -28,6 +29,12 @@ program
   .action(fetchKlines);
 program.command('compute:indicators').action(computeIndicators);
 program.command('detect:patterns').action(detectPatterns);
+program
+  .command('resample')
+  .requiredOption('--from <interval>')
+  .requiredOption('--to <interval>')
+  .requiredOption('--symbol <symbol>')
+  .action(resampleCandles);
 program
   .command('backtest:run')
   .requiredOption('--strategy <strategy>')

--- a/src/cli/resample.js
+++ b/src/cli/resample.js
@@ -1,0 +1,49 @@
+import { query } from '../storage/db.js';
+import { insertCandles } from '../storage/repos/candles.js';
+import logger from '../utils/logger.js';
+
+function intervalToMs(interval) {
+  const n = parseInt(interval.slice(0, -1));
+  const unit = interval.slice(-1);
+  const mult = { m: 60_000, h: 3_600_000, d: 86_400_000 }[unit];
+  return n * mult;
+}
+
+export async function resampleCandles(opts) {
+  const { from, to, symbol } = opts;
+  const fromMs = intervalToMs(from);
+  const toMs = intervalToMs(to);
+  if (toMs % fromMs !== 0) {
+    throw new Error('target interval must be multiple of source interval');
+  }
+  const rows = await query(
+    `select open_time, open, high, low, close, volume from candles_${from} where symbol=$1 order by open_time`,
+    [symbol]
+  );
+  const out = [];
+  let curr = null;
+  for (const r of rows) {
+    const t = Number(r.open_time);
+    const bucket = Math.floor(t / toMs) * toMs;
+    if (!curr || bucket !== curr.openTime) {
+      if (curr) out.push(curr);
+      curr = {
+        openTime: bucket,
+        open: Number(r.open),
+        high: Number(r.high),
+        low: Number(r.low),
+        close: Number(r.close),
+        volume: Number(r.volume),
+      };
+    } else {
+      curr.high = Math.max(curr.high, Number(r.high));
+      curr.low = Math.min(curr.low, Number(r.low));
+      curr.close = Number(r.close);
+      curr.volume += Number(r.volume);
+    }
+  }
+  if (curr) out.push(curr);
+  if (out.length > 0) await insertCandles(symbol, out, to);
+  logger.info(`resampled ${out.length} candles from ${from} to ${to}`);
+}
+


### PR DESCRIPTION
## Summary
- add CLI command to resample lower interval candles into higher interval
- wire resample command in executable

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c20a4582c08325b985f0587960852d