### PR TITLE
feat: support interval options for compute and patterns

### DIFF
--- a/bin/cs
+++ b/bin/cs
@@ -27,8 +27,16 @@ program
   .option('--resume')
   .option('--server-time')
   .action(fetchKlines);
-program.command('compute:indicators').action(computeIndicators);
-program.command('detect:patterns').action(detectPatterns);
+program
+  .command('compute:indicators')
+  .requiredOption('--symbol <symbol>')
+  .requiredOption('--interval <interval>')
+  .action((opts) => computeIndicators(opts));
+program
+  .command('detect:patterns')
+  .requiredOption('--symbol <symbol>')
+  .requiredOption('--interval <interval>')
+  .action((opts) => detectPatterns(opts));
 program
   .command('resample')
   .requiredOption('--from <interval>')

--- a/src/cli/compute.js
+++ b/src/cli/compute.js
@@ -9,9 +9,9 @@ import { hhll } from '../core/indicators/hhll.js';
 import logger from '../utils/logger.js';
 
 export async function computeIndicators(opts) {
-  const { symbol } = opts;
+  const { symbol, interval } = opts;
   const candles = await query(
-    'select open_time, open, high, low, close, volume from candles_1m where symbol=$1 order by open_time',
+    `select open_time, open, high, low, close, volume from candles_${interval} where symbol=$1 order by open_time`,
     [symbol]
   );
   const highs = [];
@@ -34,7 +34,7 @@ export async function computeIndicators(opts) {
     };
     rows.push({ openTime: c.open_time, data });
   }
-  await upsertIndicators(symbol, rows);
+  await upsertIndicators(symbol, rows, interval);
   logger.info(`computed ${rows.length} indicator rows`);
 }
 

--- a/src/cli/patterns.js
+++ b/src/cli/patterns.js
@@ -7,11 +7,12 @@ import logger from '../utils/logger.js';
 
 export async function detectPatterns({
   symbol,
+  interval,
   hammer: hammerOptions = {},
   star: starOptions = {},
 } = {}) {
   const candles = await query(
-    'select open_time, open, high, low, close from candles_1m where symbol=$1 order by open_time',
+    `select open_time, open, high, low, close from candles_${interval} where symbol=$1 order by open_time`,
     [symbol]
   );
 
@@ -40,7 +41,7 @@ export async function detectPatterns({
   }
 
   if (rows.length > 0) {
-    await upsertPatterns(symbol, rows);
+    await upsertPatterns(symbol, rows, interval);
   }
 
   logger.info('detect patterns');

--- a/src/storage/repos/indicators.js
+++ b/src/storage/repos/indicators.js
@@ -1,11 +1,12 @@
 import { withTransaction } from '../db.js';
 
-export async function upsertIndicators(symbol, rows) {
+export async function upsertIndicators(symbol, rows, interval = '1m') {
+  const table = `indicators_${interval}`;
   await withTransaction(async (client) => {
     await Promise.all(
       rows.map((r) =>
         client.query(
-          `insert into indicators_1m (symbol, open_time, data)
+          `insert into ${table} (symbol, open_time, data)
            values ($1,$2,$3)
            on conflict (symbol, open_time) do update set data=$3`,
           [symbol, r.openTime, r.data]

--- a/src/storage/repos/patterns.js
+++ b/src/storage/repos/patterns.js
@@ -1,11 +1,12 @@
 import { withTransaction } from '../db.js';
 
-export async function upsertPatterns(symbol, rows) {
+export async function upsertPatterns(symbol, rows, interval = '1m') {
+  const table = `patterns_${interval}`;
   await withTransaction(async (client) => {
     await Promise.all(
       rows.map((r) =>
         client.query(
-          `insert into patterns_1m (symbol, open_time, bullish_engulfing, bearish_engulfing, hammer, shooting_star)
+          `insert into ${table} (symbol, open_time, bullish_engulfing, bearish_engulfing, hammer, shooting_star)
            values ($1,$2,$3,$4,$5,$6)
            on conflict (symbol, open_time)
            do update set bullish_engulfing=$3, bearish_engulfing=$4, hammer=$5, shooting_star=$6`,

--- a/test/integration/compute.test.js
+++ b/test/integration/compute.test.js
@@ -30,7 +30,7 @@ jest.unstable_mockModule('../../src/storage/db.js', () => ({ query: queryMock })
 const { computeIndicators } = await import('../../src/cli/compute.js');
 
 test('computeIndicators upserts computed indicator values', async () => {
-  await computeIndicators({ symbol: 'SOLUSDT' });
+  await computeIndicators({ symbol: 'SOLUSDT', interval: '1m' });
 
   expect(queryMock).toHaveBeenCalled();
   expect(upsertMock).toHaveBeenCalledTimes(1);

--- a/test/integration/patterns.test.js
+++ b/test/integration/patterns.test.js
@@ -26,7 +26,7 @@ await import('../../src/storage/db.js');
 const { detectPatterns } = await import('../../src/cli/patterns.js');
 
 test('detect patterns and write to db', async () => {
-  await detectPatterns({ symbol: 'BTCUSDT' });
+await detectPatterns({ symbol: 'BTCUSDT', interval: '1m' });
   const insertCalls = query.mock.calls.filter((c) =>
     c[0].includes('insert into patterns_1m')
   );

--- a/test/unit/detectPatterns.test.js
+++ b/test/unit/detectPatterns.test.js
@@ -25,6 +25,7 @@ const { detectPatterns } = await import('../../src/cli/patterns.js');
 test('detectPatterns uses custom multipliers', async () => {
   await detectPatterns({
     symbol: 'BTCUSDT',
+    interval: '1m',
     hammer: { lowerMultiplier: 1.5 },
     star: { upperMultiplier: 1.3 },
   });


### PR DESCRIPTION
## Summary
- require --symbol and --interval for compute:indicators and detect:patterns commands
- computeIndicators and detectPatterns now use interval-specific tables
- allow upserting indicators and patterns for arbitrary intervals

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68c20b2684008325806fe586ef8b712d