### PR TITLE
feat: require interval for backtest

### DIFF
--- a/bin/cs
+++ b/bin/cs
@@ -47,6 +47,7 @@ program
   .command('backtest:run')
   .requiredOption('--strategy <strategy>')
   .requiredOption('--symbol <symbol>')
+  .requiredOption('--interval <interval>')
   .requiredOption('--from <from>')
   .requiredOption('--to <to>')
   .requiredOption('--initial <initial>')

--- a/src/cli/backtest.js
+++ b/src/cli/backtest.js
@@ -36,8 +36,8 @@ export async function backtestRun(opts) {
   let signals = signalsInput;
   if (!signals) {
     const rows = await query(
-      `select open_time, signal from signals where symbol=$1 and strategy=$2 and open_time >= $3 and open_time <= $4 order by open_time`,
-      [symbol, strategy, from, to]
+      `select open_time, signal from signals where symbol=$1 and strategy=$2 and interval=$3 and open_time >= $4 and open_time <= $5 order by open_time`,
+      [symbol, strategy, interval, from, to]
     );
     const map = new Map(rows.map((r) => [Number(r.open_time), r.signal]));
     signals = candles.map((c) => map.get(c.openTime) || null);

--- a/test/integration/backtest-cli.test.js
+++ b/test/integration/backtest-cli.test.js
@@ -40,6 +40,7 @@ test('backtest runs using DB data', async () => {
   expect(queryMock).toHaveBeenCalledTimes(2);
   expect(queryMock.mock.calls[0][0]).toMatch(/candles_1m/);
   expect(queryMock.mock.calls[1][0]).toMatch(/signals/);
+  expect(queryMock.mock.calls[1][1][2]).toBe('1m');
   expect(tradesRepo.insertTradesPaper).toHaveBeenCalled();
   expect(equityRepo.insertEquityPaper).toHaveBeenCalled();
   expect(tradesRepo.insertTradesPaper.mock.calls[0][1].length).toBeGreaterThan(0);


### PR DESCRIPTION
## Summary
- require `--interval` for `backtest:run`
- include interval in backtest queries for signals

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c20c8c167083259ecdd20f1888d346