### PR TITLE
Parse ISO dates for fetch range options

### DIFF
--- a/bin/cs
+++ b/bin/cs
@@ -37,8 +37,8 @@ program.command('db:seed').action(dbSeed);
 program
   .command('fetch:klines')
   .requiredOption('--symbol <symbol>')
-  .option('--from <ms>')
-  .option('--to <ms>')
+  .option('--from <time>', 'start time in ms or ISO 8601 string')
+  .option('--to <time>', 'end time in ms or ISO 8601 string')
   .option('--interval <interval>', '1m')
   .option('--fetch-limit <number>', '1000')
   .option('--resume')

--- a/src/cli/fetch.js
+++ b/src/cli/fetch.js
@@ -13,8 +13,17 @@ export async function fetchKlines(opts) {
     limit,
     dryRun
   } = opts;
-  let startMs = from ? Number(from) : undefined;
-  let endMs = to ? Number(to) : undefined;
+
+  const parseTime = (value) => {
+    if (value === undefined) return undefined;
+    const numeric = Number(value);
+    if (!Number.isNaN(numeric)) return numeric;
+    const ms = Date.parse(value);
+    return Number.isNaN(ms) ? undefined : ms;
+  };
+
+  let startMs = parseTime(from);
+  let endMs = parseTime(to);
   if (serverTime) {
     const serverMs = await fetchServerTime();
     const offset = serverMs - Date.now();

--- a/test/unit/fetch-cli-parse.test.js
+++ b/test/unit/fetch-cli-parse.test.js
@@ -1,0 +1,30 @@
+import { jest } from '@jest/globals';
+
+const fetchKlinesRange = jest.fn(async () => 0);
+
+jest.unstable_mockModule('../../src/core/binance.js', () => ({
+  fetchKlinesRange,
+  fetchServerTime: jest.fn(),
+  getServerTime: jest.fn()
+}));
+
+const { fetchKlines } = await import('../../src/cli/fetch.js');
+
+beforeEach(() => {
+  fetchKlinesRange.mockClear();
+});
+
+test('parses ISO date strings for from and to', async () => {
+  const from = '2024-01-01T00:00:00Z';
+  const to = '2024-01-02T00:00:00Z';
+  await fetchKlines({ symbol: 'TEST', from, to });
+  expect(fetchKlinesRange).toHaveBeenCalledWith(
+    expect.objectContaining({
+      symbol: 'TEST',
+      interval: '1m',
+      startMs: Date.parse(from),
+      endMs: Date.parse(to)
+    })
+  );
+});
+


### PR DESCRIPTION
## Summary
- allow `fetch:klines` to accept ISO 8601 strings for `--from`/`--to`
- document accepted time formats in CLI help
- add unit test for ISO date parsing

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c26c688d788325852139717fc0cbbb