### PR TITLE
docs: add CLI command documentation

### DIFF
--- a/docs/backtest-run.md
+++ b/docs/backtest-run.md
@@ -1,0 +1,26 @@
+# backtest:run
+
+Paleidžia pasirinktos strategijos backtestą pagal istorines žvakes ir signalus.
+
+## Naudojimas
+```bash
+node bin/cs backtest:run --strategy SidewaysReversal --symbol BTCUSDT \
+  --interval 1m --from 1700000000000 --to 1700003600000 --initial 1000 [OPCIJOS]
+```
+
+## Opcijos
+- `--strategy <strategy>` – privalomas; šiuo metu `SidewaysReversal` arba `BBRevert`.
+- `--symbol <symbol>` – privalomas.
+- `--interval <interval>` – privalomas.
+- `--from <ms>` / `--to <ms>` – laikų rėžiai.
+- `--initial <sum>` – pradinė balanso suma.
+- Globalios: `--dry-run`, `--limit`, `--verbose`.
+
+## Aktyvumo srautas
+1. Krauna žvakes iš DB (arba iš failo, jei perduota per `--candles` – kodu).
+2. Krauna signalus (jei nėra, generuoja iš DB).
+3. Vykdo `runBacktest`, gaudamas `trades`, `equity`, `metrics`.
+4. Įrašo `trades_paper` ir `equity_paper` (nebent `--dry-run`).
+5. Sugeneruoja `out/backtest/<...>/` aplanką su CSV/JSON rezultatais.
+6. Išveda „backtest completed“.
+

--- a/docs/compute-indicators.md
+++ b/docs/compute-indicators.md
@@ -1,0 +1,20 @@
+# compute:indicators
+
+Apskaičiuoja techninius indikatorius konkrečiai porai ir intervalui.
+
+## Naudojimas
+```bash
+node bin/cs compute:indicators --symbol BTCUSDT --interval 1m [OPCIJOS]
+```
+
+## Opcijos
+- `--symbol <symbol>` – privalomas.
+- `--interval <interval>` – privalomas.
+- Globalios: `--dry-run`, `--limit`, `--verbose`.
+
+## Aktyvumo srautas
+1. Nuskaito žvakes iš `candles_<interval>` lentelės.
+2. Slenkančiu būdu skaičiuoja RSI, ATR, Aroon, Bollinger, Trend, HH/LL.
+3. Įrašo rezultatus į `indicators_<interval>` (nebent `--dry-run`).
+4. Išveda apdorotų eilučių skaičių.
+

--- a/docs/db-init.md
+++ b/docs/db-init.md
@@ -1,0 +1,20 @@
+# db:init
+
+Inicializuoja duomenų bazę naudojant SQL skriptą `migrations/db.init.sql`.
+
+## Naudojimas
+```bash
+node bin/cs db:init [OPCIJOS]
+```
+
+## Opcijos
+- `--dry-run` – neveikia DB, tik parodo pranešimą.
+- `--verbose` – detalesni logai.
+- `--limit <n>` – globalus (čia nenaudojamas).
+
+## Aktyvumo srautas
+1. Perskaito `migrations/db.init.sql`.
+2. Prisijungia prie PostgreSQL.
+3. Vykdo skriptą.
+4. Išveda „database initialized“.
+

--- a/docs/db-migrate.md
+++ b/docs/db-migrate.md
@@ -1,0 +1,19 @@
+# db:migrate
+
+Vykdo „npm run migrate“ – paleidžia migracijas.
+
+## Naudojimas
+```bash
+node bin/cs db:migrate [OPCIJOS]
+```
+
+## Opcijos
+- `--dry-run` – praleidžia migraciją.
+- `--verbose` – detalesni logai.
+- `--limit <n>` – globalus (nenaudojamas).
+
+## Aktyvumo srautas
+1. Patikrina `--dry-run`.
+2. Spawnina procesą `npm run migrate`.
+3. Laukia proceso pabaigos ir praneša rezultatą.
+

--- a/docs/db-seed.md
+++ b/docs/db-seed.md
@@ -1,0 +1,19 @@
+# db:seed
+
+Užpildo `symbols` lentelę pradiniais įrašais.
+
+## Naudojimas
+```bash
+node bin/cs db:seed [OPCIJOS]
+```
+
+## Opcijos
+- `--dry-run` – praleidžia seed’inimą.
+- `--verbose` – detalesni logai.
+- `--limit <n>` – globalus (nenaudojamas).
+
+## Aktyvumo srautas
+1. Paleidžia skriptą `scripts/seed-symbols.js`.
+2. Įrašo simbolių sąrašą į DB.
+3. Išveda „database seeded“.
+

--- a/docs/detect-patterns.md
+++ b/docs/detect-patterns.md
@@ -1,0 +1,20 @@
+# detect:patterns
+
+Atpažįsta žvakių formacijas ir trend struktūrą.
+
+## Naudojimas
+```bash
+node bin/cs detect:patterns --symbol BTCUSDT --interval 1m [OPCIJOS]
+```
+
+## Opcijos
+- `--symbol <symbol>` – privalomas.
+- `--interval <interval>` – privalomas.
+- Globalios: `--dry-run`, `--limit`, `--verbose`.
+
+## Aktyvumo srautas
+1. Nuskaito žvakes iš `candles_<interval>`.
+2. Tikrina bullish/bearish engulfing, hammer, shooting star.
+3. Įrašo rezultatus į `patterns_<interval>` (nebent `--dry-run`).
+4. Išveda logą „detect patterns“.
+

--- a/docs/fetch-klines.md
+++ b/docs/fetch-klines.md
@@ -1,0 +1,25 @@
+# fetch:klines
+
+Atsisiunčia OHLCV žvakes iš Binance ir įrašo į DB.
+
+## Naudojimas
+```bash
+node bin/cs fetch:klines --symbol BTCUSDT [OPCIJOS]
+```
+
+## Opcijos
+- `--symbol <symbol>` – privalomas; pora, pvz., `BTCUSDT`.
+- `--from <time>` – pradžios laikas (ms arba ISO).
+- `--to <time>` – pabaigos laikas (ms arba ISO).
+- `--interval <interval>` – numatytas `1m`.
+- `--fetch-limit <number>` – maksimalus žvakių kiekis per API skambutį (1000).
+- `--resume` – tėsia nuo paskutinės įrašytos žvakės.
+- `--server-time` – suderina laiką su Binance serveriu.
+- Globalios: `--dry-run`, `--limit`, `--verbose`.
+
+## Aktyvumo srautas
+1. Išparsiuoja laikus ir prireikus juos pakoreguoja pagal serverio laiką.
+2. Kartotinai kviečia Binance `/klines` API.
+3. Įrašo gautas žvakes į `candles_<interval>` lentelę (nebent `--dry-run`).
+4. Išveda surinktų žvakių skaičių.
+

--- a/docs/jobs-list.md
+++ b/docs/jobs-list.md
@@ -1,0 +1,18 @@
+# jobs:list
+
+Rodo paskutinius vykdytus darbus iš `jobs` lentelės.
+
+## Naudojimas
+```bash
+node bin/cs jobs:list [--limit 10] [OPCIJOS]
+```
+
+## Opcijos
+- `--limit <n>` – kiek įrašų rodyti; numatyta `10`.
+- Globalios: `--dry-run`, `--verbose`.
+
+## Aktyvumo srautas
+1. Atlieka `select id, name, run_at from jobs order by run_at desc limit n`.
+2. Išrašo kiekvieną eilutę į logus.
+3. Grąžina sąrašą (naudinga programiniam naudojimui).
+

--- a/docs/jobs-run.md
+++ b/docs/jobs-run.md
@@ -1,0 +1,21 @@
+# jobs:run
+
+Paleidžia suplanuotą darbą pagal tipą (pvz., `backtest`).
+
+## Naudojimas
+```bash
+node bin/cs jobs:run --type backtest --params '{"symbol":"BTCUSDT",...}' [OPCIJOS]
+```
+
+## Opcijos
+- `--type <type>` – privalomas; šiuo metu palaikomas `backtest`.
+- `--params <json>` – JSON parametrai konkrečiam darbui.
+- Globalios: `--dry-run`, `--limit`, `--verbose`.
+
+## Aktyvumo srautas
+1. Parenka `handler` pagal `type`.
+2. `JSON.parse` ant `--params`.
+3. Paleidžia atitinkamą funkciją (pvz., `backtestRun`).
+4. Atnaujina `jobs` lentelę `run_at` lauku.
+5. Išveda „job <type> completed“.
+

--- a/docs/paper-equity-snapshot.md
+++ b/docs/paper-equity-snapshot.md
@@ -1,0 +1,19 @@
+# paper:equity:snapshot
+
+Įrašo dabartinį “paper trading“ kapitalo dydį.
+
+## Naudojimas
+```bash
+node bin/cs paper:equity:snapshot --equity 10500 --source live [OPCIJOS]
+```
+
+## Opcijos
+- `--equity <sum>` – privalomas; balansas.
+- `--source <name>` – privalomas; šaltinio identifikatorius.
+- Globalios: `--dry-run`, `--verbose`.
+
+## Aktyvumo srautas
+1. Paimamas dabartinis laiko žymuo.
+2. Įrašo į `equity_paper` lentelę (nebent `--dry-run`).
+3. Išveda „equity snapshot recorded“.
+

--- a/docs/resample.md
+++ b/docs/resample.md
@@ -1,0 +1,22 @@
+# resample
+
+Perrašo žvakes iš vieno intervalo į kitą (pvz., 1m → 5m).
+
+## Naudojimas
+```bash
+node bin/cs resample --from 1m --to 5m --symbol BTCUSDT [OPCIJOS]
+```
+
+## Opcijos
+- `--from <interval>` – privalomas, pradinio intervalo ilgis.
+- `--to <interval>` – privalomas, tikslo intervalas.
+- `--symbol <symbol>` – privalomas.
+- Globalios: `--dry-run`, `--limit`, `--verbose`.
+
+## Aktyvumo srautas
+1. Paverčia intervalus į milisekundes ir patikrina, ar `to` yra `from` daugiklis.
+2. Grupuoja šaltinio žvakes į naujus “bucket’us“.
+3. Apskaičiuoja naujas atidarymo/uždarymo/high/low/volume reikšmes.
+4. Įrašo į `candles_<to>` (nebent `--dry-run`).
+5. Išveda resamplintų žvakių kiekį.
+

--- a/docs/signals-generate.md
+++ b/docs/signals-generate.md
@@ -1,0 +1,23 @@
+# signals:generate
+
+Generuoja pirkimo/pardavimo signalus pagal pasirinktą strategiją.
+
+## Naudojimas
+```bash
+node bin/cs signals:generate --symbol BTCUSDT --interval 1m \
+  --strategy SidewaysReversal [OPCIJOS]
+```
+
+## Opcijos
+- `--symbol <symbol>` – privalomas.
+- `--interval <interval>` – privalomas.
+- `--strategy <strategy>` – privalomas (`SidewaysReversal` arba `BBRevert`).
+- Globalios: `--dry-run`, `--limit`, `--verbose`.
+
+## Aktyvumo srautas
+1. Nuskaito indikatorius ir žvakes iš DB.
+2. Susieja su pattern’ais (`patterns_<interval>`).
+3. Per `runStrategy` paleidžia strategiją kiekvienai žvakei.
+4. Įrašo signalus į `signals` lentelę (nebent `--dry-run`).
+5. Išveda sugeneruotų signalų skaičių.
+


### PR DESCRIPTION
## Summary
- add usage guides for database commands
- document data processing, trading, and job management CLI commands

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c26f065cf883258b79d9884844376a