### PR TITLE
Fix signals upsert by adding unique index

### DIFF
--- a/migrations/1700000000000_init.js
+++ b/migrations/1700000000000_init.js
@@ -123,7 +123,7 @@ export async function up(pgm) {
     run_at: { type: 'bigint' }
   });
 
-  pgm.createIndex('signals', ['symbol', 'open_time']);
+  pgm.createIndex('signals', ['symbol', 'open_time'], { unique: true });
 }
 
 export async function down(pgm) {

--- a/migrations/db.structure.sql
+++ b/migrations/db.structure.sql
@@ -112,7 +112,7 @@ create table if not exists signals
 alter table signals
     owner to laimonas;
 
-create index if not exists signals_symbol_open_time_index
+create unique index if not exists signals_symbol_open_time_index
     on signals (symbol, open_time);
 
 create table if not exists trades_paper


### PR DESCRIPTION
## Summary
- enforce uniqueness on `signals` table `(symbol, open_time)` for proper upsert behavior

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c27417eae48325a85fa02a0bbedc27