### PR TITLE
feat: store signals per strategy and interval

### DIFF
--- a/migrations/1700000000003_signals_strategy_interval_index.js
+++ b/migrations/1700000000003_signals_strategy_interval_index.js
@@ -1,0 +1,61 @@
+export async function up(pgm) {
+  pgm.noTransaction();
+
+  // Add interval and strategy columns if missing.
+  pgm.addColumn('signals', { interval: { type: 'text', notNull: true, default: '1m' } }, { ifNotExists: true });
+  pgm.addColumn('signals', { strategy: { type: 'text', notNull: true, default: 'unknown' } }, { ifNotExists: true });
+
+  // Remove defaults so future inserts must specify values explicitly.
+  pgm.alterColumn('signals', 'interval', { default: null });
+  pgm.alterColumn('signals', 'strategy', { default: null });
+
+  // Remove any duplicates before enforcing uniqueness.
+  pgm.sql(`
+    WITH dups AS (
+      SELECT id, ROW_NUMBER() OVER (
+        PARTITION BY symbol, interval, open_time, strategy
+        ORDER BY id DESC
+      ) AS rn
+      FROM signals
+    )
+    DELETE FROM signals
+    USING dups
+    WHERE signals.id = dups.id AND dups.rn > 1;
+  `);
+
+  // Drop old unique index if present.
+  pgm.dropIndex('signals', ['symbol', 'open_time'], {
+    name: 'signals_symbol_open_time_index',
+    ifExists: true,
+    concurrently: true,
+  });
+
+  // Create new unique index on (symbol, interval, open_time, strategy).
+  pgm.createIndex('signals', ['symbol', 'interval', 'open_time', 'strategy'], {
+    name: 'signals_symbol_interval_open_time_strategy_index',
+    unique: true,
+    ifNotExists: true,
+    concurrently: true,
+  });
+}
+
+export async function down(pgm) {
+  pgm.noTransaction();
+
+  pgm.dropIndex('signals', ['symbol', 'interval', 'open_time', 'strategy'], {
+    name: 'signals_symbol_interval_open_time_strategy_index',
+    ifExists: true,
+    concurrently: true,
+  });
+
+  pgm.dropColumn('signals', 'interval', { ifExists: true });
+  pgm.dropColumn('signals', 'strategy', { ifExists: true });
+
+  pgm.createIndex('signals', ['symbol', 'open_time'], {
+    unique: true,
+    name: 'signals_symbol_open_time_index',
+    ifNotExists: true,
+    concurrently: true,
+  });
+}
+

--- a/src/cli/signals.js
+++ b/src/cli/signals.js
@@ -50,6 +50,6 @@ export async function signalsGenerate(opts) {
     if (sig) signals.push({ openTime: row.open_time, signal: sig });
   }
 
-  if (!dryRun) await upsertSignals(symbol, signals);
+  if (!dryRun) await upsertSignals(symbol, interval, strategyName, signals);
   logger.info(`generated ${signals.length} signals`);
 }

--- a/src/storage/repos/equityPaper.js
+++ b/src/storage/repos/equityPaper.js
@@ -4,7 +4,11 @@ export async function insertEquityPaper(source, symbol, equity) {
   for (const e of equity) {
     await query(
       `insert into equity_paper (ts, equity, source, symbol)
-       values ($1,$2,$3,$4)`,
+       values ($1,$2,$3,$4)
+       on conflict (ts) do update
+       set equity = excluded.equity,
+           source = excluded.source,
+           symbol = excluded.symbol`,
       [e.time, e.balance, source, symbol]
     );
   }

--- a/src/storage/repos/signals.js
+++ b/src/storage/repos/signals.js
@@ -1,14 +1,16 @@
 import { withTransaction } from '../db.js';
 
-export async function upsertSignals(symbol, signals) {
+// Upsert signals keeping strategy and interval distinction.
+// This ensures that different strategies or intervals do not overwrite each other.
+export async function upsertSignals(symbol, interval, strategy, signals) {
   await withTransaction(async (client) => {
     await Promise.all(
       signals.map((s) =>
         client.query(
-          `insert into signals (symbol, open_time, signal)
-           values ($1,$2,$3)
-           on conflict (symbol, open_time) do update set signal = excluded.signal`,
-          [symbol, s.openTime, s.signal]
+          `insert into signals (symbol, interval, open_time, strategy, signal)
+           values ($1,$2,$3,$4,$5)
+           on conflict (symbol, interval, open_time, strategy) do update set signal = excluded.signal`,
+          [symbol, interval, s.openTime, strategy, s.signal]
         )
       )
     );
@@ -16,3 +18,4 @@ export async function upsertSignals(symbol, signals) {
 }
 
 export default { upsertSignals };
+

--- a/test/integration/signals-generate.test.js
+++ b/test/integration/signals-generate.test.js
@@ -38,7 +38,7 @@ const { signalsGenerate } = await import('../../src/cli/signals.js');
 
 it('uses close price for BBRevert strategy', async () => {
   await signalsGenerate({ symbol: 'BTCUSDT', interval: '1m', strategy: 'BBRevert' });
-  expect(upsertSignals).toHaveBeenCalledWith('BTCUSDT', [
+  expect(upsertSignals).toHaveBeenCalledWith('BTCUSDT', '1m', 'BBRevert', [
     { openTime: 1, signal: 'buy' },
     { openTime: 2, signal: 'sell' }
   ]);

--- a/test/integration/strategies.test.js
+++ b/test/integration/strategies.test.js
@@ -52,7 +52,7 @@ describe('signals generation and backtest integration', () => {
       ]);
 
     await signalsGenerate({ symbol: 'BTC', interval: '1m', strategy: 'SidewaysReversal' });
-    expect(upsertMock).toHaveBeenCalledWith('BTC', [
+    expect(upsertMock).toHaveBeenCalledWith('BTC', '1m', 'SidewaysReversal', [
       { openTime: 2, signal: 'buy' },
       { openTime: 3, signal: 'sell' },
     ]);
@@ -64,7 +64,7 @@ describe('signals generation and backtest integration', () => {
       close: c.close,
     }));
 
-    const generated = upsertMock.mock.calls[0][1];
+    const generated = upsertMock.mock.calls[0][3];
     const signals = candles.map(c => {
       const s = generated.find(g => g.openTime === c.openTime);
       return s ? s.signal : null;
@@ -114,7 +114,7 @@ describe('signals generation and backtest integration', () => {
       ]);
 
     await signalsGenerate({ symbol: 'ETH', interval: '1m', strategy: 'BBRevert' });
-    expect(upsertMock).toHaveBeenCalledWith('ETH', [
+    expect(upsertMock).toHaveBeenCalledWith('ETH', '1m', 'BBRevert', [
       { openTime: 2, signal: 'buy' },
       { openTime: 3, signal: 'sell' },
     ]);
@@ -126,7 +126,7 @@ describe('signals generation and backtest integration', () => {
       close: c.close,
     }));
 
-    const generated = upsertMock.mock.calls[0][1];
+    const generated = upsertMock.mock.calls[0][3];
     const signals = candles.map(c => {
       const s = generated.find(g => g.openTime === c.openTime);
       return s ? s.signal : null;

--- a/test/unit/equityPaper-repo.test.js
+++ b/test/unit/equityPaper-repo.test.js
@@ -4,10 +4,11 @@ const query = jest.fn();
 await jest.unstable_mockModule('../../src/storage/db.js', () => ({ query }));
 const { insertEquityPaper } = await import('../../src/storage/repos/equityPaper.js');
 
-test('inserts paper equity records', async () => {
+test('upserts paper equity records', async () => {
   await insertEquityPaper('paper', 'BTC', [{ time: 1, balance: 100 }]);
-  expect(query).toHaveBeenCalledWith(
-    expect.stringContaining('insert into equity_paper'),
-    [1, 100, 'paper', 'BTC']
-  );
+  expect(query).toHaveBeenCalledTimes(1);
+  const [sql, params] = query.mock.calls[0];
+  expect(sql).toContain('insert into equity_paper');
+  expect(sql.toLowerCase()).toContain('on conflict (ts) do update');
+  expect(params).toEqual([1, 100, 'paper', 'BTC']);
 });

--- a/test/unit/signals-repo.test.js
+++ b/test/unit/signals-repo.test.js
@@ -6,11 +6,11 @@ await jest.unstable_mockModule('../../src/storage/db.js', () => ({ withTransacti
 const { upsertSignals } = await import('../../src/storage/repos/signals.js');
 
 test('upserts signals with conflict handling', async () => {
-  await upsertSignals('BTC', [{ openTime: 1, signal: 'BUY' }]);
+  await upsertSignals('BTC', '1m', 'test', [{ openTime: 1, signal: 'BUY' }]);
   expect(query).toHaveBeenCalledWith(
     expect.stringContaining('insert into signals'),
-    ['BTC', 1, 'BUY']
+    ['BTC', '1m', 1, 'test', 'BUY']
   );
   const sql = query.mock.calls[0][0];
-  expect(sql).toMatch(/on conflict \(symbol, open_time\) do update set signal = excluded.signal/);
+  expect(sql).toMatch(/on conflict \(symbol, interval, open_time, strategy\) do update set signal = excluded.signal/);
 });

--- a/test/unit/signals.test.js
+++ b/test/unit/signals.test.js
@@ -40,7 +40,7 @@ test('generates signals for SidewaysReversal strategy', async () => {
       },
     ]);
   await signalsGenerate({ symbol: 'BTC', interval: '1m', strategy: 'SidewaysReversal' });
-  expect(upsertMock).toHaveBeenCalledWith('BTC', [
+  expect(upsertMock).toHaveBeenCalledWith('BTC', '1m', 'SidewaysReversal', [
     { openTime: 1, signal: 'buy' },
     { openTime: 2, signal: 'sell' },
   ]);
@@ -69,7 +69,7 @@ test('generates signals for BBRevert strategy', async () => {
       },
     ]);
   await signalsGenerate({ symbol: 'ETH', interval: '1m', strategy: 'BBRevert' });
-  expect(upsertMock).toHaveBeenCalledWith('ETH', [
+  expect(upsertMock).toHaveBeenCalledWith('ETH', '1m', 'BBRevert', [
     { openTime: 1, signal: 'buy' },
     { openTime: 2, signal: 'sell' },
   ]);


### PR DESCRIPTION
## Summary
- track signals separately by strategy and interval
- add migration that enforces unique `(symbol, interval, open_time, strategy)` index
- update tests for new signal storage shape
- upsert equity snapshots to avoid duplicate key errors in backtests

## Testing
- `npm test`
- `npm run lint`
- `npm run migrate` *(fails: connect ECONNREFUSED)*
- `node bin/cs backtest:run --strategy SidewaysReversal --symbol BTCUSDT --interval 1m --from 0 --to 60000 --initial 10000` *(fails: connect ECONNREFUSED)*

------
https://chatgpt.com/codex/tasks/task_e_68c2870b57608325876e61013da2d13d