### PR TITLE
Use config for logger log level

### DIFF
--- a/src/utils/logger.js
+++ b/src/utils/logger.js
@@ -1,3 +1,7 @@
 import pino from 'pino';
-export const logger = pino({ level: process.env.APP_LOG_LEVEL || 'info' });
+import config from '../config/index.js';
+
+export const logger = pino();
+logger.level = config.app.logLevel;
+
 export default logger;


### PR DESCRIPTION
## Summary
- use centralized config module for logger log level

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c3253628408325a57f9d9196054cd1