### PR TITLE
feat: make SidewaysReversal strategy configurable

### DIFF
--- a/src/cli/signals.js
+++ b/src/cli/signals.js
@@ -7,13 +7,14 @@ import logger from '../utils/logger.js';
 
 const STRATEGIES = {
   SidewaysReversal,
-  BBRevert,
+  BBRevert: () => BBRevert,
 };
 
 export async function signalsGenerate(opts) {
-  const { symbol, interval, strategy: strategyName, dryRun, limit } = opts;
-  const strategy = STRATEGIES[strategyName];
-  if (!strategy) throw new Error(`Unknown strategy: ${strategyName}`);
+  const { symbol, interval, strategy: strategyName, strategyConfig, dryRun, limit } = opts;
+  const strategyFactory = STRATEGIES[strategyName];
+  if (!strategyFactory) throw new Error(`Unknown strategy: ${strategyName}`);
+  const strategy = strategyFactory(strategyConfig ? JSON.parse(strategyConfig) : undefined);
 
   const indicators = await query(
     `select i.open_time, i.data, c.close

--- a/src/core/signals/strategies/SidewaysReversal.js
+++ b/src/core/signals/strategies/SidewaysReversal.js
@@ -1,19 +1,21 @@
-export default {
-  name: 'SidewaysReversal',
-  entry(ind) {
-    const sideways = ind.trend === 'range';
-    const oversold = typeof ind.rsi === 'number' && ind.rsi <= 30;
-    if (sideways && oversold && ind.bullishEngulfing) {
-      return 'buy';
-    }
-    return null;
-  },
-  exit(ind) {
-    const notSideways = ind.trend !== 'range';
-    const overbought = typeof ind.rsi === 'number' && ind.rsi >= 70;
-    if (notSideways || overbought || ind.bearishEngulfing) {
-      return 'sell';
-    }
-    return null;
-  }
-};
+export default function SidewaysReversal({ oversoldRsi = 30, overboughtRsi = 70 } = {}) {
+  return {
+    name: 'SidewaysReversal',
+    entry(ind) {
+      const sideways = ind.trend === 'range';
+      const oversold = typeof ind.rsi === 'number' && ind.rsi <= oversoldRsi;
+      if (sideways && oversold && ind.bullishEngulfing) {
+        return 'buy';
+      }
+      return null;
+    },
+    exit(ind) {
+      const notSideways = ind.trend !== 'range';
+      const overbought = typeof ind.rsi === 'number' && ind.rsi >= overboughtRsi;
+      if (notSideways || overbought || ind.bearishEngulfing) {
+        return 'sell';
+      }
+      return null;
+    },
+  };
+}

--- a/test/unit/engine.test.js
+++ b/test/unit/engine.test.js
@@ -3,6 +3,6 @@ import SidewaysReversal from '../../src/core/signals/strategies/SidewaysReversal
 
 test('runStrategy returns buy', () => {
   const ind = { trend: 'range', rsi: 20, bullishEngulfing: true };
-  const sig = runStrategy(SidewaysReversal, ind);
+  const sig = runStrategy(SidewaysReversal(), ind);
   expect(sig).toBe('buy');
 });

--- a/test/unit/signals/SidewaysReversal.test.js
+++ b/test/unit/signals/SidewaysReversal.test.js
@@ -2,23 +2,31 @@ import { runStrategy } from '../../../src/core/signals/engine.js';
 import SidewaysReversal from '../../../src/core/signals/strategies/SidewaysReversal.js';
 
 describe('SidewaysReversal strategy', () => {
-  test('returns buy on range trend, oversold RSI and bullish engulfing', () => {
-    const ind = { trend: 'range', rsi: 20, bullishEngulfing: true };
-    expect(runStrategy(SidewaysReversal, ind)).toBe('buy');
+  test('uses oversoldRsi from config for buy signals', () => {
+    const strategy = SidewaysReversal({ oversoldRsi: 25 });
+    const buyInd = { trend: 'range', rsi: 24, bullishEngulfing: true };
+    const noBuyInd = { trend: 'range', rsi: 26, bullishEngulfing: true };
+    expect(runStrategy(strategy, buyInd)).toBe('buy');
+    expect(runStrategy(strategy, noBuyInd)).toBeNull();
   });
 
-  test('returns sell on overbought RSI', () => {
-    const ind = { trend: 'range', rsi: 75 };
-    expect(runStrategy(SidewaysReversal, ind)).toBe('sell');
+  test('uses overboughtRsi from config for sell signals', () => {
+    const strategy = SidewaysReversal({ overboughtRsi: 65 });
+    const sellInd = { trend: 'range', rsi: 66 };
+    const noSellInd = { trend: 'range', rsi: 64 };
+    expect(runStrategy(strategy, sellInd)).toBe('sell');
+    expect(runStrategy(strategy, noSellInd)).toBeNull();
   });
 
   test('returns sell on bearish engulfing pattern', () => {
+    const strategy = SidewaysReversal();
     const ind = { trend: 'range', rsi: 40, bearishEngulfing: true };
-    expect(runStrategy(SidewaysReversal, ind)).toBe('sell');
+    expect(runStrategy(strategy, ind)).toBe('sell');
   });
 
   test('returns sell when trend breaks range', () => {
+    const strategy = SidewaysReversal();
     const ind = { trend: 'up', rsi: 40 };
-    expect(runStrategy(SidewaysReversal, ind)).toBe('sell');
+    expect(runStrategy(strategy, ind)).toBe('sell');
   });
 });


### PR DESCRIPTION
## Summary
- allow SidewaysReversal to be created with custom RSI thresholds
- pass JSON `strategyConfig` to strategy factories when generating signals
- expand tests to cover strategy configuration

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68c33b9937188325be86518b5aeae960