### PR TITLE
feat: allow passing strategy config

### DIFF
--- a/bin/cs
+++ b/bin/cs
@@ -68,12 +68,14 @@ program
   .requiredOption('--from <from>')
   .requiredOption('--to <to>')
   .requiredOption('--initial <initial>')
+  .option('--strategy-config <json>')
   .action(backtestRun);
 program
   .command('signals:generate')
   .requiredOption('--symbol <symbol>')
   .requiredOption('--interval <interval>')
   .requiredOption('--strategy <strategy>')
+  .option('--strategy-config <json>')
   .action(signalsGenerate);
 
 program

--- a/docs/backtest-run.md
+++ b/docs/backtest-run.md
@@ -5,7 +5,8 @@ Paleidžia pasirinktos strategijos backtestą pagal istorines žvakes ir signalu
 ## Naudojimas
 ```bash
 node bin/cs backtest:run --strategy SidewaysReversal --symbol BTCUSDT \
-  --interval 1m --from 1700000000000 --to 1700003600000 --initial 1000 [OPCIJOS]
+  --interval 1m --from 1700000000000 --to 1700003600000 --initial 1000 \
+  --strategy-config '{"oversoldRsi":25}' [OPCIJOS]
 ```
 
 ## Opcijos
@@ -14,6 +15,7 @@ node bin/cs backtest:run --strategy SidewaysReversal --symbol BTCUSDT \
 - `--interval <interval>` – privalomas.
 - `--from <ms>` / `--to <ms>` – laikų rėžiai.
 - `--initial <sum>` – pradinė balanso suma.
+- `--strategy-config <json>` – papildoma strategijos konfigūracija.
 - Globalios: `--dry-run`, `--limit`, `--verbose`.
 
 ## Aktyvumo srautas

--- a/docs/crypto-signals-cli-spec.md
+++ b/docs/crypto-signals-cli-spec.md
@@ -234,10 +234,10 @@ cs compute:indicators --symbol SOLUSDT --interval 1m
 cs detect:patterns --symbol SOLUSDT --interval 1m
 
 # Signalai
-cs signals:generate --strategy SidewaysReversal --symbol SOLUSDT --interval 1m --from 2025-01-01
+cs signals:generate --strategy SidewaysReversal --symbol SOLUSDT --interval 1m --from 2025-01-01 --strategy-config '{"oversoldRsi":25}'
 
 # Backtest / paper
-cs backtest:run --strategy SidewaysReversal --symbol SOLUSDT --interval 1m --from 2025-06-01 --to 2025-09-01 --initial 10000
+cs backtest:run --strategy SidewaysReversal --symbol SOLUSDT --interval 1m --from 2025-06-01 --to 2025-09-01 --initial 10000 --strategy-config '{"oversoldRsi":25}'
 cs paper:equity:snapshot --equity 10150 --source live
 
 # Jobs

--- a/docs/signals-generate.md
+++ b/docs/signals-generate.md
@@ -5,13 +5,14 @@ Generuoja pirkimo/pardavimo signalus pagal pasirinktą strategiją.
 ## Naudojimas
 ```bash
 node bin/cs signals:generate --symbol BTCUSDT --interval 1m \
-  --strategy SidewaysReversal [OPCIJOS]
+  --strategy SidewaysReversal --strategy-config '{"oversoldRsi":25}' [OPCIJOS]
 ```
 
 ## Opcijos
 - `--symbol <symbol>` – privalomas.
 - `--interval <interval>` – privalomas.
 - `--strategy <strategy>` – privalomas (`SidewaysReversal` arba `BBRevert`).
+- `--strategy-config <json>` – papildoma strategijos konfigūracija.
 - Globalios: `--dry-run`, `--limit`, `--verbose`.
 
 ## Aktyvumo srautas

--- a/docs/user.guide.md
+++ b/docs/user.guide.md
@@ -38,7 +38,8 @@
 
 Sugeneruokite signalus pasirinkta strategija:
 ```bash
-node bin/cs signals:generate --symbol BTCUSDT --interval 1m --strategy SidewaysReversal
+node bin/cs signals:generate --symbol BTCUSDT --interval 1m \
+  --strategy SidewaysReversal --strategy-config '{"oversoldRsi":25}'
 ```
 Komanda įrašys pirkimo ir pardavimo signalus į `signals` lentelę ir išves, kiek jų buvo sugeneruota.
 

--- a/src/cli/backtest.js
+++ b/src/cli/backtest.js
@@ -16,6 +16,7 @@ export async function backtestRun(opts) {
     initial,
     candles: candlesInput,
     signals: signalsInput,
+    strategyConfig,
     dryRun,
     limit,
     ...rest
@@ -93,7 +94,8 @@ export async function backtestRun(opts) {
     to,
     interval,
     initial,
-    ...rest
+    ...(strategyConfig && { strategyConfig: JSON.parse(strategyConfig) }),
+    ...rest,
   };
   await fs.writeFile(
     path.join(outDir, 'config.json'),

--- a/test/integration/backtest-output.test.js
+++ b/test/integration/backtest-output.test.js
@@ -33,6 +33,7 @@ test('backtest generates metrics and files', async () => {
     signals,
     atrPeriod: 1,
     atrMultiplier: 1,
+    strategyConfig: '{"foo":"bar"}',
   });
 
   expect(metrics.winrate).toBeCloseTo(0.5);
@@ -46,6 +47,9 @@ test('backtest generates metrics and files', async () => {
   for (const f of files) {
     await expect(fs.access(path.join(outDir, f))).resolves.toBeUndefined();
   }
+
+  const cfg = JSON.parse(await fs.readFile(path.join(outDir, 'config.json'), 'utf8'));
+  expect(cfg.strategyConfig).toEqual({ foo: 'bar' });
 
   await fs.rm(path.join('out', 'backtest', dirName), { recursive: true, force: true });
 });

--- a/test/integration/signals-generate.test.js
+++ b/test/integration/signals-generate.test.js
@@ -37,7 +37,7 @@ jest.unstable_mockModule('../../src/storage/repos/signals.js', () => ({
 const { signalsGenerate } = await import('../../src/cli/signals.js');
 
 it('uses close price for BBRevert strategy', async () => {
-  await signalsGenerate({ symbol: 'BTCUSDT', interval: '1m', strategy: 'BBRevert' });
+  await signalsGenerate({ symbol: 'BTCUSDT', interval: '1m', strategy: 'BBRevert', strategyConfig: '{}' });
   expect(upsertSignals).toHaveBeenCalledWith('BTCUSDT', '1m', 'BBRevert', [
     { openTime: 1, signal: 'buy' },
     { openTime: 2, signal: 'sell' }

--- a/test/integration/strategies.test.js
+++ b/test/integration/strategies.test.js
@@ -51,7 +51,7 @@ describe('signals generation and backtest integration', () => {
         },
       ]);
 
-    await signalsGenerate({ symbol: 'BTC', interval: '1m', strategy: 'SidewaysReversal' });
+    await signalsGenerate({ symbol: 'BTC', interval: '1m', strategy: 'SidewaysReversal', strategyConfig: '{}' });
     expect(upsertMock).toHaveBeenCalledWith('BTC', '1m', 'SidewaysReversal', [
       { openTime: 2, signal: 'buy' },
       { openTime: 3, signal: 'sell' },
@@ -113,7 +113,7 @@ describe('signals generation and backtest integration', () => {
         },
       ]);
 
-    await signalsGenerate({ symbol: 'ETH', interval: '1m', strategy: 'BBRevert' });
+    await signalsGenerate({ symbol: 'ETH', interval: '1m', strategy: 'BBRevert', strategyConfig: '{}' });
     expect(upsertMock).toHaveBeenCalledWith('ETH', '1m', 'BBRevert', [
       { openTime: 2, signal: 'buy' },
       { openTime: 3, signal: 'sell' },

--- a/test/unit/signals.test.js
+++ b/test/unit/signals.test.js
@@ -39,7 +39,7 @@ test('generates signals for SidewaysReversal strategy', async () => {
         shooting_star: false,
       },
     ]);
-  await signalsGenerate({ symbol: 'BTC', interval: '1m', strategy: 'SidewaysReversal' });
+  await signalsGenerate({ symbol: 'BTC', interval: '1m', strategy: 'SidewaysReversal', strategyConfig: '{}' });
   expect(upsertMock).toHaveBeenCalledWith('BTC', '1m', 'SidewaysReversal', [
     { openTime: 1, signal: 'buy' },
     { openTime: 2, signal: 'sell' },
@@ -68,7 +68,7 @@ test('generates signals for BBRevert strategy', async () => {
         shooting_star: false,
       },
     ]);
-  await signalsGenerate({ symbol: 'ETH', interval: '1m', strategy: 'BBRevert' });
+  await signalsGenerate({ symbol: 'ETH', interval: '1m', strategy: 'BBRevert', strategyConfig: '{}' });
   expect(upsertMock).toHaveBeenCalledWith('ETH', '1m', 'BBRevert', [
     { openTime: 1, signal: 'buy' },
     { openTime: 2, signal: 'sell' },


### PR DESCRIPTION
## Summary
- support --strategy-config for signals:generate and backtest:run
- persist strategyConfig in backtest config output
- document new strategy option and add regression tests

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c33d76b46483259748488e6e5d6cb6