### PR TITLE
Ensure sell signals only follow buys

### DIFF
--- a/test/integration/strategies.test.js
+++ b/test/integration/strategies.test.js
@@ -143,4 +143,42 @@ describe('signals generation and backtest integration', () => {
     expect(trades.length).toBeGreaterThan(0);
     expect(equity.length).toBe(candles.length);
   });
+
+  test('ignores sell signals when not in position', async () => {
+    queryMock
+      .mockResolvedValueOnce([
+        { open_time: 1, data: { trend: 'up', rsi: 80 }, close: 0 },
+        { open_time: 2, data: { trend: 'range', rsi: 20 }, close: 0 },
+        { open_time: 3, data: { trend: 'up', rsi: 80 }, close: 0 },
+      ])
+      .mockResolvedValueOnce([
+        {
+          open_time: 1,
+          bullish_engulfing: false,
+          bearish_engulfing: false,
+          hammer: false,
+          shooting_star: false,
+        },
+        {
+          open_time: 2,
+          bullish_engulfing: true,
+          bearish_engulfing: false,
+          hammer: false,
+          shooting_star: false,
+        },
+        {
+          open_time: 3,
+          bullish_engulfing: false,
+          bearish_engulfing: false,
+          hammer: false,
+          shooting_star: false,
+        },
+      ]);
+
+    await signalsGenerate({ symbol: 'BTC', interval: '1m', strategy: 'SidewaysReversal', strategyConfig: '{}' });
+    expect(upsertMock).toHaveBeenCalledWith('BTC', '1m', 'SidewaysReversal', [
+      { openTime: 2, signal: 'buy' },
+      { openTime: 3, signal: 'sell' },
+    ]);
+  });
 });


### PR DESCRIPTION
## Summary
- track open position state in signal generation loop to pair buys with sells
- add regression test verifying sells without preceding buys are ignored

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68c33fabd450832582ae401ff0a5fd78