### PR TITLE
test: ensure signals include paired buy and sell

### DIFF
--- a/test/integration/strategies.test.js
+++ b/test/integration/strategies.test.js
@@ -181,4 +181,34 @@ describe('signals generation and backtest integration', () => {
       { openTime: 3, signal: 'sell' },
     ]);
   });
+
+  test('produces buy then sell for entry/exit sequence', async () => {
+    queryMock
+      .mockResolvedValueOnce([
+        { open_time: 1, data: { trend: 'range', rsi: 20 }, close: 0 },
+        { open_time: 2, data: { trend: 'up', rsi: 80 }, close: 0 },
+      ])
+      .mockResolvedValueOnce([
+        {
+          open_time: 1,
+          bullish_engulfing: true,
+          bearish_engulfing: false,
+          hammer: false,
+          shooting_star: false,
+        },
+        {
+          open_time: 2,
+          bullish_engulfing: false,
+          bearish_engulfing: false,
+          hammer: false,
+          shooting_star: false,
+        },
+      ]);
+
+    await signalsGenerate({ symbol: 'BTC', interval: '1m', strategy: 'SidewaysReversal', strategyConfig: '{}' });
+    expect(upsertMock).toHaveBeenCalledWith('BTC', '1m', 'SidewaysReversal', [
+      { openTime: 1, signal: 'buy' },
+      { openTime: 2, signal: 'sell' },
+    ]);
+  });
 });


### PR DESCRIPTION
## Summary
- add regression test to ensure entry/exit sequence generates buy and sell signals

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c34295711c83259cab9f3f1ef5953f