### PR TITLE
feat: add 30m interval

### DIFF
--- a/docs/add-interval.md
+++ b/docs/add-interval.md
@@ -1,0 +1,29 @@
+# Pridėti naują žvakių intervalą
+
+Šiame pavyzdyje pridedame 30 minučių (`30m`) intervalą.
+
+## 1. Lentelės duomenų bazėje
+Sukurkite migraciją ir pridėkite lenteles `candles_30m`, `indicators_30m`, `patterns_30m`.
+Pavyzdys yra faile `migrations/1700000000004_add_30m_interval.js`.
+
+Paleiskite migracijas:
+```bash
+node bin/cs db:migrate
+```
+
+## 2. Užpildykite žvakes
+Jei turite 1m žvakes, galite agreguoti jas į 30m:
+```bash
+node bin/cs resample --symbol BTCUSDT --from 1m --to 30m
+```
+
+## 3. Apskaičiuokite indikatorius ir patternus
+```bash
+node bin/cs compute:indicators --symbol BTCUSDT --interval 30m
+node bin/cs detect:patterns --symbol BTCUSDT --interval 30m
+```
+
+Po šių žingsnių `--interval 30m` veiks visose komandose, pvz.:
+```bash
+node bin/cs signals:generate --symbol BTCUSDT --interval 30m --strategy SidewaysReversal
+```

--- a/docs/crypto-signals-cli-spec.md
+++ b/docs/crypto-signals-cli-spec.md
@@ -71,6 +71,7 @@ candles_1m(
   unique(symbol, ts)
 );
 
+-- candles_30m(...) tas pats formatas, kitas intervalas
 -- candles_1h(...) tas pats formatas, kitas intervalas
 
 indicators_1m(

--- a/migrations/1700000000004_add_30m_interval.js
+++ b/migrations/1700000000004_add_30m_interval.js
@@ -1,0 +1,44 @@
+export async function up(pgm) {
+  pgm.createTable(
+    'candles_30m',
+    {
+      symbol: { type: 'text', notNull: true },
+      open_time: { type: 'bigint', notNull: true },
+      open: 'numeric',
+      high: 'numeric',
+      low: 'numeric',
+      close: 'numeric',
+      volume: 'numeric'
+    },
+    { constraints: { primaryKey: ['symbol', 'open_time'] } }
+  );
+
+  pgm.createTable(
+    'indicators_30m',
+    {
+      symbol: { type: 'text', notNull: true },
+      open_time: { type: 'bigint', notNull: true },
+      data: { type: 'jsonb', notNull: true }
+    },
+    { constraints: { primaryKey: ['symbol', 'open_time'] } }
+  );
+
+  pgm.createTable(
+    'patterns_30m',
+    {
+      symbol: { type: 'text', notNull: true },
+      open_time: { type: 'bigint', notNull: true },
+      bullish_engulfing: { type: 'boolean', notNull: true, default: false },
+      bearish_engulfing: { type: 'boolean', notNull: true, default: false },
+      hammer: { type: 'boolean', notNull: true, default: false },
+      shooting_star: { type: 'boolean', notNull: true, default: false }
+    },
+    { constraints: { primaryKey: ['symbol', 'open_time'] } }
+  );
+}
+
+export async function down(pgm) {
+  pgm.dropTable('patterns_30m');
+  pgm.dropTable('indicators_30m');
+  pgm.dropTable('candles_30m');
+}

--- a/test/integration/fetch-range.test.js
+++ b/test/integration/fetch-range.test.js
@@ -12,7 +12,7 @@ const fetchMock = jest.fn(async url => {
   const end = Number(u.searchParams.get('endTime'));
   const limit = Number(u.searchParams.get('limit'));
   const interval = u.searchParams.get('interval');
-  const stepMap = { '1m': 60_000, '1h': 3_600_000, '1d': 86_400_000 };
+  const stepMap = { '1m': 60_000, '30m': 1_800_000, '1h': 3_600_000, '1d': 86_400_000 };
   const step = stepMap[interval];
   const candles = [];
   for (let t = start; (!end || t < end) && candles.length < limit; t += step) {
@@ -183,9 +183,22 @@ test('supports multiple intervals', async () => {
     endMs: 3 * 3_600_000,
     limit: 1000
   });
-  const url = new URL(fetchMock.mock.calls[0][0]);
+  let url = new URL(fetchMock.mock.calls[0][0]);
   expect(url.searchParams.get('interval')).toBe('1h');
   expect(insertMock.mock.calls[0][2]).toBe('1h');
+
+  fetchMock.mockClear();
+  insertMock.mockClear();
+  await fetchKlinesRange({
+    symbol: 'BTCUSDT',
+    interval: '30m',
+    startMs: 0,
+    endMs: 3 * 1_800_000,
+    limit: 1000
+  });
+  url = new URL(fetchMock.mock.calls[0][0]);
+  expect(url.searchParams.get('interval')).toBe('30m');
+  expect(insertMock.mock.calls[0][2]).toBe('30m');
 });
 
 test('syncs server time', async () => {


### PR DESCRIPTION
## Summary
- add migration for 30m candle, indicator and pattern tables
- document how to add a new candle interval
- cover 30m interval in fetch range tests

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68c5eaedd6e08325a2dab21e13c5f7b6