### PR TITLE
Convert signals open_time to timestamp

### DIFF
--- a/migrations/1700000000005_convert_signals_open_time.js
+++ b/migrations/1700000000005_convert_signals_open_time.js
@@ -1,0 +1,13 @@
+export async function up(pgm) {
+  pgm.alterColumn('signals', 'open_time', {
+    type: 'timestamp',
+    using: "to_timestamp(open_time / 1000) AT TIME ZONE 'Europe/Vilnius'",
+  });
+}
+
+export async function down(pgm) {
+  pgm.alterColumn('signals', 'open_time', {
+    type: 'bigint',
+    using: "(extract(epoch from open_time AT TIME ZONE 'Europe/Vilnius') * 1000)::bigint",
+  });
+}


### PR DESCRIPTION
## Summary
- convert signals.open_time from bigint epoch to human-readable timestamp in Europe/Vilnius timezone

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c68e11e6f48325a3261099de2aa187