### PR TITLE
Add human-readable open_time column for signals

### DIFF
--- a/migrations/1700000000007_add_open_time_dt.js
+++ b/migrations/1700000000007_add_open_time_dt.js
@@ -1,0 +1,13 @@
+export async function up(pgm) {
+  pgm.addColumn('signals', {
+    open_time_dt: {
+      type: 'timestamp',
+      notNull: true,
+      expressionGenerated: "to_timestamp(open_time / 1000) AT TIME ZONE 'Europe/Vilnius'",
+    },
+  });
+}
+
+export async function down(pgm) {
+  pgm.dropColumn('signals', 'open_time_dt');
+}


### PR DESCRIPTION
## Summary
- add generated `open_time_dt` column to `signals` converting epoch `open_time` to Europe/Vilnius timestamp
- bump migration version to avoid conflict with existing migrations

## Testing
- `npm test`
- `npm run lint`
- `npm run migrate` *(fails: connect ECONNREFUSED ::1:5432)*

------
https://chatgpt.com/codex/tasks/task_e_68c68e11e6f48325a3261099de2aa187