### PR TITLE
Recreate signals table with timestamp open_time

### DIFF
--- a/migrations/1700000000008_recreate_signals.js
+++ b/migrations/1700000000008_recreate_signals.js
@@ -1,0 +1,35 @@
+export async function up(pgm) {
+  pgm.dropTable('signals', { ifExists: true });
+  pgm.createTable('signals', {
+    id: 'id',
+    symbol: { type: 'text', notNull: true },
+    open_time: { type: 'timestamp', notNull: true },
+    interval: { type: 'text', notNull: true },
+    strategy: { type: 'text', notNull: true },
+    signal: { type: 'text', notNull: true },
+  });
+  pgm.createIndex('signals', ['symbol', 'interval', 'open_time', 'strategy'], {
+    name: 'signals_symbol_interval_open_time_strategy_index',
+    unique: true,
+    ifNotExists: true,
+  });
+}
+
+export async function down(pgm) {
+  pgm.dropIndex('signals', ['symbol', 'interval', 'open_time', 'strategy'], {
+    name: 'signals_symbol_interval_open_time_strategy_index',
+    ifExists: true,
+  });
+  pgm.dropTable('signals', { ifExists: true });
+  pgm.createTable('signals', {
+    id: 'id',
+    symbol: { type: 'text', notNull: true },
+    open_time: { type: 'bigint', notNull: true },
+    signal: { type: 'text', notNull: true },
+  });
+  pgm.createIndex('signals', ['symbol', 'open_time'], {
+    name: 'signals_symbol_open_time_index',
+    unique: true,
+    ifNotExists: true,
+  });
+}


### PR DESCRIPTION
## Summary
- remove previous open_time_dt migration
- recreate signals table so open_time is stored as a timestamp and enforce uniqueness on symbol, interval, open_time, and strategy

## Testing
- `npm test`
- `npm run lint`
- `npm run migrate` *(fails: connect ECONNREFUSED; postgres not running)*

------
https://chatgpt.com/codex/tasks/task_e_68c68e11e6f48325a3261099de2aa187