### PR TITLE
Recreate signals table with timestamp open_time

### DIFF
--- a/migrations/1700000000008_recreate_signals.js
+++ b/migrations/1700000000008_recreate_signals.js
@@ -1,0 +1,35 @@
+export async function up(pgm) {
+  pgm.dropTable('signals', { ifExists: true });
+  pgm.createTable('signals', {
+    id: 'id',
+    symbol: { type: 'text', notNull: true },
+    open_time: { type: 'timestamp', notNull: true },
+    interval: { type: 'text', notNull: true },
+    strategy: { type: 'text', notNull: true },
+    signal: { type: 'text', notNull: true },
+  });
+  pgm.createIndex('signals', ['symbol', 'interval', 'open_time', 'strategy'], {
+    name: 'signals_symbol_interval_open_time_strategy_index',
+    unique: true,
+    ifNotExists: true,
+  });
+}
+
+export async function down(pgm) {
+  pgm.dropIndex('signals', ['symbol', 'interval', 'open_time', 'strategy'], {
+    name: 'signals_symbol_interval_open_time_strategy_index',
+    ifExists: true,
+  });
+  pgm.dropTable('signals', { ifExists: true });
+  pgm.createTable('signals', {
+    id: 'id',
+    symbol: { type: 'text', notNull: true },
+    open_time: { type: 'bigint', notNull: true },
+    signal: { type: 'text', notNull: true },
+  });
+  pgm.createIndex('signals', ['symbol', 'open_time'], {
+    name: 'signals_symbol_open_time_index',
+    unique: true,
+    ifNotExists: true,
+  });
+}

--- a/src/cli/backtest.js
+++ b/src/cli/backtest.js
@@ -42,7 +42,7 @@ export async function backtestRun(opts) {
   if (!signals) {
     const rows = await query(
       `select open_time, signal from signals where symbol=$1 and strategy=$2 and interval=$3 and open_time >= $4 and open_time <= $5 order by open_time`,
-      [symbol, strategy, interval, from, to]
+      [symbol, strategy, interval, new Date(Number(from)), new Date(Number(to))]
     );
     const map = new Map(rows.map((r) => [Number(r.open_time), r.signal]));
     signals = candles.map((c) => map.get(c.openTime) || null);

--- a/src/storage/repos/signals.js
+++ b/src/storage/repos/signals.js
@@ -10,7 +10,13 @@ export async function upsertSignals(symbol, interval, strategy, signals) {
           `insert into signals (symbol, interval, open_time, strategy, signal)
            values ($1,$2,$3,$4,$5)
            on conflict (symbol, interval, open_time, strategy) do update set signal = excluded.signal`,
-          [symbol, interval, s.openTime, strategy, s.signal]
+          [
+            symbol,
+            interval,
+            s.openTime instanceof Date ? s.openTime : new Date(Number(s.openTime)),
+            strategy,
+            s.signal,
+          ]
         )
       )
     );

--- a/test/unit/signals-repo.test.js
+++ b/test/unit/signals-repo.test.js
@@ -9,8 +9,10 @@ test('upserts signals with conflict handling', async () => {
   await upsertSignals('BTC', '1m', 'test', [{ openTime: 1, signal: 'BUY' }]);
   expect(query).toHaveBeenCalledWith(
     expect.stringContaining('insert into signals'),
-    ['BTC', '1m', 1, 'test', 'BUY']
+    ['BTC', '1m', expect.any(Date), 'test', 'BUY']
   );
+  const inserted = query.mock.calls[0][1][2];
+  expect(inserted).toEqual(new Date(1));
   const sql = query.mock.calls[0][0];
   expect(sql).toMatch(/on conflict \(symbol, interval, open_time, strategy\) do update set signal = excluded.signal/);
 });


### PR DESCRIPTION
## Summary
- remove previous open_time_dt migration
- recreate signals table so open_time is stored as a timestamp and enforce uniqueness on symbol, interval, open_time, and strategy
- convert numeric open_time values to timestamps on insert and query signals using timestamp bounds

## Testing
- `npm test`
- `npm run lint`
- `node bin/cs signals:generate --symbol BTCUSDT --interval 1m --strategy SidewaysReversal --strategy-config '{"oversoldRsi":30,"overboughtRsi":70}'` *(fails: connect ECONNREFUSED; postgres not running)*

------
https://chatgpt.com/codex/tasks/task_e_68c68e11e6f48325a3261099de2aa187