### PR TITLE
feat: backtest only long

### DIFF
--- a/docs/backtest-run.md
+++ b/docs/backtest-run.md
@@ -28,6 +28,7 @@ node bin/cs backtest:run --strategy SidewaysReversal --symbol BTCUSDT \
 
 ## Pastabos
 - Prieš paleidžiant reikia išvalyti db lentele `trades_paper`
+- Backtestas palaiko tik long sandorius; `sell` signalai uždaro atvirą poziciją ir neatidaro `short`
 
 ## Failai
 

--- a/new.spec.by.code.md
+++ b/new.spec.by.code.md
@@ -23,7 +23,7 @@ Yra įgyvendintos dvi strategijos: `BBRevert` ir `SidewaysReversal`. Strategijų
 - Modeliai: bullish/bearish engulfing, hammer ir shooting star.
 
 ## Backtest ir popierinė prekyba
-- `runBacktest` skaičiuoja laimėjimų procentą, pelno/failo santykį, maksimalų nuosmukį ir vidutinį PnL; palaiko ATR pagrįstus SL/TP lygius.
+- `runBacktest` skaičiuoja laimėjimų procentą, pelno/failo santykį, maksimalų nuosmukį ir vidutinį PnL; palaiko ATR pagrįstus SL/TP lygius ir vykdo tik long sandorius.
 - `LiveSimulator` leidžia atlikti žingsninę popierinę prekybą naudojant gautus signalus.
 
 ## Duomenų bazės struktūra

--- a/src/core/backtest/runner.js
+++ b/src/core/backtest/runner.js
@@ -66,7 +66,7 @@ export async function runBacktest({
   const highs = [];
   const lows = [];
   const closes = [];
-  let position = null; // {side, entryPrice, sl, tp, entryTime}
+  let position = null; // {entryPrice, sl, tp, entryTime}
 
   for (let i = 0; i < candles.length; i++) {
     const c = candles[i];
@@ -80,19 +80,9 @@ export async function runBacktest({
     if (!position && atrVal && signal === 'buy') {
       const entryPrice = c.close;
       position = {
-        side: 'long',
         entryPrice,
         sl: entryPrice - atrVal * atrMultiplier,
         tp: entryPrice + atrVal * atrMultiplier,
-        entryTime: c.openTime
-      };
-    } else if (!position && atrVal && signal === 'sell') {
-      const entryPrice = c.close;
-      position = {
-        side: 'short',
-        entryPrice,
-        sl: entryPrice + atrVal * atrMultiplier,
-        tp: entryPrice - atrVal * atrMultiplier,
         entryTime: c.openTime
       };
     }
@@ -100,27 +90,18 @@ export async function runBacktest({
     if (position) {
       let exitPrice = null;
       let exitTime = c.openTime;
-      if (position.side === 'long') {
-        if (c.low <= position.sl) exitPrice = position.sl;
-        else if (c.high >= position.tp) exitPrice = position.tp;
-        else if (signal === 'sell') exitPrice = c.close;
-      } else if (position.side === 'short') {
-        if (c.high >= position.sl) exitPrice = position.sl;
-        else if (c.low <= position.tp) exitPrice = position.tp;
-        else if (signal === 'buy') exitPrice = c.close;
-      }
+      if (c.low <= position.sl) exitPrice = position.sl;
+      else if (c.high >= position.tp) exitPrice = position.tp;
+      else if (signal === 'sell') exitPrice = c.close;
       if (exitPrice !== null) {
-        const pnl =
-          position.side === 'long'
-            ? exitPrice - position.entryPrice
-            : position.entryPrice - exitPrice;
+        const pnl = exitPrice - position.entryPrice;
         balance += pnl;
         trades.push({
           entryTime: position.entryTime,
           exitTime,
           entryPrice: position.entryPrice,
           exitPrice,
-          side: position.side,
+          side: 'long',
           pnl
         });
         position = null;

--- a/test/unit/backtest-runner.test.js
+++ b/test/unit/backtest-runner.test.js
@@ -1,0 +1,22 @@
+import { runBacktest } from '../../src/core/backtest/runner.js';
+
+describe('runBacktest long-only', () => {
+  test('ignores sell signals when no position is open', async () => {
+    const candles = [
+      { openTime: 1, high: 1, low: 1, close: 1 },
+      { openTime: 2, high: 2, low: 2, close: 2 },
+    ];
+    const signals = [null, 'sell'];
+
+    const { trades } = await runBacktest({
+      candles,
+      signals,
+      initialBalance: 0,
+      atrPeriod: 1,
+      atrMultiplier: 2,
+    });
+
+    expect(trades).toHaveLength(0);
+  });
+});
+


### PR DESCRIPTION
## Summary
- backtest no longer opens short positions, 'sell' signals only close longs
- document long-only backtest and update spec
- add unit test ensuring sell signals without position are ignored

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c7b27c917c8325875c0d0e52933ccb