### PR TITLE
Add scheduled signal runner script

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,3 +17,13 @@ node bin/cs fetch:klines --symbol BTCUSDT
 ```
 
 See `bin/cs --help` for all commands.
+
+## Scheduling
+
+You can automate signal generation with cron once the environment is configured:
+
+```cron
+*/30 * * * * /usr/bin/env bash /path/to/crypto-signals-cli/scripts/run-signals.sh
+```
+
+Ensure the `.env` file contains the required API keys, database credentials, and any symbol overrides before scheduling the job. The script relies on the Node.js runtime and an accessible PostgreSQL database, so install dependencies with `npm install`, run the migrations, and keep the database service running on the host where cron executes.

--- a/scripts/run-signals.sh
+++ b/scripts/run-signals.sh
@@ -1,0 +1,59 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+cd "$(dirname "$0")/.."
+
+LOG_DIR="logs"
+LOG_FILE="$LOG_DIR/signals.log"
+
+mkdir -p "$LOG_DIR"
+
+# Redirect all output to the log file for cron usage
+exec >>"$LOG_FILE" 2>&1
+
+log() {
+  local timestamp
+  timestamp="$(date '+%Y-%m-%d %H:%M:%S')"
+  printf '[%s] %s\n' "$timestamp" "$*"
+}
+
+trap 'log "Script failed at line ${LINENO}."' ERR
+
+log "Starting signal generation run."
+
+if [[ -f .env ]]; then
+  set -o allexport
+  # shellcheck disable=SC1091
+  source ".env"
+  set +o allexport
+  log "Loaded environment variables from .env."
+else
+  log "Missing .env file. Aborting."
+  exit 1
+fi
+
+SYMBOLS_FROM_ENV="${SYMBOLS:-}"
+unset SYMBOLS
+
+declare -a SYMBOLS
+if [[ -n "$SYMBOLS_FROM_ENV" ]]; then
+  IFS=', ' read -r -a SYMBOLS <<< "${SYMBOLS_FROM_ENV//,/ }"
+else
+  SYMBOLS=(BTCUSDT ETHUSDT SOLUSDT)
+fi
+
+INTERVAL="${INTERVAL:-1h}"
+STRATEGY="${STRATEGY:-sma}"
+
+log "Using interval '$INTERVAL' and strategy '$STRATEGY' for symbols: ${SYMBOLS[*]}"
+
+for symbol in "${SYMBOLS[@]}"; do
+  log "Processing $symbol"
+  node bin/cs fetch:klines --symbol "$symbol" --interval "$INTERVAL" --resume
+  node bin/cs compute:indicators --symbol "$symbol" --interval "$INTERVAL"
+  node bin/cs detect:patterns --symbol "$symbol" --interval "$INTERVAL"
+  node bin/cs signals:generate --symbol "$symbol" --interval "$INTERVAL" --strategy "$STRATEGY"
+  log "Completed $symbol"
+done
+
+log "Signal generation run finished successfully."


### PR DESCRIPTION
## Summary
- add a cron-friendly `scripts/run-signals.sh` helper that loads environment variables and logs output
- document how to schedule the signal runner from cron in the README

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68c9cd7562bc8325af9dba819bcae5f8