### PR TITLE
Fix Aroon scaling and align BBRevert with Bollinger data

### DIFF
--- a/src/core/indicators/aroon.js
+++ b/src/core/indicators/aroon.js
@@ -11,8 +11,21 @@ export function aroon(highs, lows, period = 25) {
     lowWindow.push(lows[i]);
   }
 
-  const up = (highWindow.maxAge() / (period - 1)) * 100;
-  const down = (lowWindow.minAge() / (period - 1)) * 100;
+  const denominator = period - 1;
+  if (denominator === 0) {
+    return { up: 100, down: 100 };
+  }
 
-  return { up, down };
+  const upAge = highWindow.maxAge();
+  const downAge = lowWindow.minAge();
+
+  if (upAge == null || downAge == null) return null;
+
+  const up = ((denominator - upAge) / denominator) * 100;
+  const down = ((denominator - downAge) / denominator) * 100;
+
+  return {
+    up: Math.max(0, Math.min(100, up)),
+    down: Math.max(0, Math.min(100, down)),
+  };
 }

--- a/src/core/signals/strategies/BBRevert.js
+++ b/src/core/signals/strategies/BBRevert.js
@@ -1,7 +1,20 @@
 export default {
   name: 'BBRevert',
   rules: [
-    { when: i => i.close < i.bbands.lower, signal: 'buy' },
-    { when: i => i.close > i.bbands.upper || i.rsi > 70, signal: 'sell' }
+    {
+      when: i => {
+        const lower = i.bollinger?.lower;
+        return typeof lower === 'number' && i.close < lower;
+      },
+      signal: 'buy',
+    },
+    {
+      when: i => {
+        const upper = i.bollinger?.upper;
+        const closeAboveUpper = typeof upper === 'number' && i.close > upper;
+        return closeAboveUpper || i.rsi > 70;
+      },
+      signal: 'sell',
+    }
   ]
 };

--- a/test/integration/signals-generate.test.js
+++ b/test/integration/signals-generate.test.js
@@ -1,8 +1,8 @@
 import { jest } from '@jest/globals';
 
 const indicators = [
-  { open_time: 1, data: { bbands: { lower: 100, upper: 110 } }, close: 90 },
-  { open_time: 2, data: { bbands: { lower: 100, upper: 110 } }, close: 120 }
+  { open_time: 1, data: { bollinger: { lower: 100, upper: 110 } }, close: 90 },
+  { open_time: 2, data: { bollinger: { lower: 100, upper: 110 } }, close: 120 }
 ];
 const patterns = [
   {

--- a/test/integration/strategies.test.js
+++ b/test/integration/strategies.test.js
@@ -85,9 +85,9 @@ describe('signals generation and backtest integration', () => {
   test('BBRevert generates signals and backtest produces trades', async () => {
     queryMock
       .mockResolvedValueOnce([
-        { open_time: 1, data: { price: 100, bbands: { lower: 90, upper: 110 } }, close: 100 },
-        { open_time: 2, data: { price: 80, bbands: { lower: 90, upper: 110 } }, close: 80 },
-        { open_time: 3, data: { price: 120, bbands: { lower: 90, upper: 110 } }, close: 120 },
+        { open_time: 1, data: { price: 100, bollinger: { lower: 90, upper: 110 } }, close: 100 },
+        { open_time: 2, data: { price: 80, bollinger: { lower: 90, upper: 110 } }, close: 80 },
+        { open_time: 3, data: { price: 120, bollinger: { lower: 90, upper: 110 } }, close: 120 },
       ])
       .mockResolvedValueOnce([
         {

--- a/test/unit/indicators.test.js
+++ b/test/unit/indicators.test.js
@@ -16,6 +16,19 @@ test('trend up/down/range', () => {
   expect(trend(110, 100, 80, 50)).toBe('up');
   expect(trend(90, 100, 30, 70)).toBe('down');
   expect(trend(100, 100, 50, 50)).toBe('range');
+  expect(trend(100, null, 100, 0)).toBe('range');
+});
+
+test('trend reflects fresh highs and lows from aroon', () => {
+  const bullishHighs = [1, 2, 3, 4, 6];
+  const bullishLows = [0, 1, 2, 3, 4];
+  const bullishAroon = aroon(bullishHighs, bullishLows, 5);
+  expect(trend(110, 100, bullishAroon.up, bullishAroon.down)).toBe('up');
+
+  const bearishHighs = [6, 5, 4, 3, 2];
+  const bearishLows = [5, 4, 3, 2, 1];
+  const bearishAroon = aroon(bearishHighs, bearishLows, 5);
+  expect(trend(90, 100, bearishAroon.up, bearishAroon.down)).toBe('down');
 });
 
 test('hhll higher high & higher low', () => {
@@ -42,12 +55,20 @@ test('atr constant range', () => {
   expect(res).toBeCloseTo(2);
 });
 
-test('aroon extremes', () => {
+test('aroon newest extremes score highest', () => {
   const highs = [1, 2, 3];
-  const lows = [1, 2, 3];
+  const lows = [3, 2, 1];
   const res = aroon(highs, lows, 3);
-  expect(res.up).toBe(0);
+  expect(res.up).toBe(100);
   expect(res.down).toBe(100);
+});
+
+test('aroon older extremes decay towards zero', () => {
+  const highs = [1, 3, 5, 4, 2];
+  const lows = [5, 1, 3, 2, 4];
+  const res = aroon(highs, lows, 5);
+  expect(res.up).toBeCloseTo(50);
+  expect(res.down).toBeCloseTo(25);
 });
 
 test('bollinger flat', () => {

--- a/test/unit/signals.test.js
+++ b/test/unit/signals.test.js
@@ -49,8 +49,8 @@ test('generates signals for SidewaysReversal strategy', async () => {
 test('generates signals for BBRevert strategy', async () => {
   queryMock
     .mockResolvedValueOnce([
-      { open_time: 1, data: { bbands: { lower: 100, upper: 110 } }, close: 90 },
-      { open_time: 2, data: { bbands: { lower: 100, upper: 110 } }, close: 120 },
+      { open_time: 1, data: { bollinger: { lower: 100, upper: 110 } }, close: 90 },
+      { open_time: 2, data: { bollinger: { lower: 100, upper: 110 } }, close: 120 },
     ])
     .mockResolvedValueOnce([
       {

--- a/test/unit/signals/BBRevert.test.js
+++ b/test/unit/signals/BBRevert.test.js
@@ -4,7 +4,7 @@ import BBRevert from '../../../src/core/signals/strategies/BBRevert.js';
 test('entry returns buy when conditions met', () => {
   const ind = {
     close: 90,
-    bbands: { lower: 100, upper: 110 },
+    bollinger: { lower: 100, upper: 110 },
     aroon: { up: 60 },
     rsi: 50,
   };
@@ -15,7 +15,7 @@ test('entry returns buy when conditions met', () => {
 test('exit returns sell when close above upper band', () => {
   const ind = {
     close: 120,
-    bbands: { lower: 100, upper: 110 },
+    bollinger: { lower: 100, upper: 110 },
     aroon: { up: 40 },
     rsi: 50,
   };
@@ -26,10 +26,18 @@ test('exit returns sell when close above upper band', () => {
 test('no signal when rsi below 70 and price inside bands', () => {
   const ind = {
     close: 105,
-    bbands: { lower: 100, upper: 110 },
+    bollinger: { lower: 100, upper: 110 },
     aroon: { up: 40 },
     rsi: 65,
   };
   const sig = runStrategy(BBRevert, ind);
   expect(sig).toBeNull();
+});
+
+test('sell signal falls back to rsi when bands missing', () => {
+  const ind = {
+    close: 105,
+    rsi: 72,
+  };
+  expect(runStrategy(BBRevert, ind)).toBe('sell');
 });


### PR DESCRIPTION
## Summary
- correct the Aroon indicator to score newest highs/lows at 100 and clamp output to 0–100
- guard BBRevert strategy against missing Bollinger data and use the proper indicator key
- expand indicator and strategy tests to cover the new behaviour and prevent regressions

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68cbf335b3f483259abc0a487af314ee